### PR TITLE
change staff_api schema and add pagination

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./user_api:/usr/src/app
     ports:
-      - "3000:3000"
+      - "3002:3000"
     depends_on:
       - db
     command: tail -f /dev/null
@@ -40,7 +40,7 @@ services:
   user_db_gui:
     image: sosedoff/pgweb
     ports:
-      - "3010:8081"
+      - "3012:8081"
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/user_development?sslmode=disable
     depends_on:
@@ -54,14 +54,14 @@ services:
     volumes:
       - ./inquiry_api:/usr/src/app
     ports:
-      - "3001:3000"
+      - "3003:3000"
     depends_on:
       - db
 
   inquiry_db_gui:
     image: sosedoff/pgweb
     ports:
-      - "3011:8081"
+      - "3013:8081"
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/inquiry_development?sslmode=disable
     depends_on:
@@ -78,14 +78,14 @@ services:
     volumes:
       - ./staff_api:/go/src/app
     ports:
-      - 3002:3000
+      - 3001:3000
     depends_on:
       - db
 
   staff_db_gui:
     image: sosedoff/pgweb
     ports:
-      - "3012:8081"
+      - "3011:8081"
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/staff_development?sslmode=disable
     depends_on:
@@ -102,7 +102,7 @@ services:
     volumes:
       - ./auth_api:/go/src/app
     ports:
-      - 3003:3000
+      - 3004:3000
 
 volumes:
   postgres-data:

--- a/staff_api/gqlgen.yml
+++ b/staff_api/gqlgen.yml
@@ -31,3 +31,7 @@ models:
       - github.com/99designs/gqlgen/graphql.Int32
   Staff:
     model: staff_api/graph/model.Staff
+  PageInfo:
+    model: staff_api/graph/model.PageInfo
+  StaffList:
+    model: staff_api/graph/model.StaffList

--- a/staff_api/graph/model/models_gen.go
+++ b/staff_api/graph/model/models_gen.go
@@ -14,6 +14,10 @@ type StaffChangePasswordInput struct {
 	NewPassword string `json:"newPassword"`
 }
 
+type StaffIDInput struct {
+	ID string `json:"id"`
+}
+
 type StaffIconInput struct {
 	ID   string `json:"id"`
 	Icon string `json:"icon"`

--- a/staff_api/graph/model/staff.go
+++ b/staff_api/graph/model/staff.go
@@ -15,6 +15,18 @@ type Staff struct {
 	UpdatedAt string `json:"updatedAt"`
 }
 
+type PageInfo struct {
+	CurrentPage int `json:"currentPage"`
+	RecordCount int `json:"recordCount"`
+	PageCount   int `json:"pageCount"`
+	Limit       int `json:"limit"`
+}
+
+type StaffList struct {
+	PageInfo *PageInfo `json:"pageInfo"`
+	Staffs   []*Staff  `json:"staffs"`
+}
+
 func StaffFromEntity(e *entity.Staff) *Staff {
 	return &Staff{
 		ID:        fmt.Sprintf("%d", e.ID),

--- a/staff_api/graph/schema.graphqls
+++ b/staff_api/graph/schema.graphqls
@@ -11,8 +11,21 @@ type Staff {
   updatedAt: String!
 }
 
+type PageInfo {
+  currentPage: Int!
+  recordCount: Int!
+  pageCount: Int!
+  limit: Int!
+}
+
+type StaffList {
+  pageInfo: PageInfo!
+  staffs: [Staff!]!
+}
+
 type Query {
   staffs: [Staff!]!
+  staffList(page: Int, per: Int): StaffList!
   staff(id: ID!): Staff!
 }
 
@@ -26,6 +39,10 @@ input StaffInput {
   id: ID!
   name: String
   email: String
+}
+
+input StaffIDInput {
+  id: ID!
 }
 
 input StaffIconInput {
@@ -43,7 +60,7 @@ type Mutation {
   createStaff(input: NewStaffInput): Staff!
   updateStaff(input: StaffInput): Staff!
   changeStaffPassword(input: StaffChangePasswordInput): Staff!
-  deleteStaff(id: ID!): Staff!
+  deleteStaff(input: StaffIDInput): Staff!
   uploadStaffIcon(input: StaffIconInput): Staff!
-  deleteStaffIcon(id: ID!): Staff!
+  deleteStaffIcon(input: StaffIDInput): Staff!
 }

--- a/staff_api/graph/schema.resolvers.go
+++ b/staff_api/graph/schema.resolvers.go
@@ -84,13 +84,13 @@ func (r *mutationResolver) ChangeStaffPassword(ctx context.Context, input *model
 	return model.StaffFromEntity(&staff), nil
 }
 
-func (r *mutationResolver) DeleteStaff(ctx context.Context, id string) (*model.Staff, error) {
+func (r *mutationResolver) DeleteStaff(ctx context.Context, input *model.StaffIDInput) (*model.Staff, error) {
 	var staff entity.Staff
-	if count := r.DB.First(&staff, id).RowsAffected; count == 0 {
+	if count := r.DB.First(&staff, input.ID).RowsAffected; count == 0 {
 		return nil, gqlerror.Errorf("対象のレコードは存在しません")
 	}
 
-	if err := r.DB.Delete(&staff, id).Error; err != nil {
+	if err := r.DB.Delete(&staff, input.ID).Error; err != nil {
 		return nil, gqlerror.Errorf("レコードの削除に失敗しました")
 	}
 
@@ -114,9 +114,9 @@ func (r *mutationResolver) UploadStaffIcon(ctx context.Context, input *model.Sta
 	return model.StaffFromEntity(&staff), nil
 }
 
-func (r *mutationResolver) DeleteStaffIcon(ctx context.Context, id string) (*model.Staff, error) {
+func (r *mutationResolver) DeleteStaffIcon(ctx context.Context, input *model.StaffIDInput) (*model.Staff, error) {
 	var staff entity.Staff
-	if count := r.DB.First(&staff, id).RowsAffected; count == 0 {
+	if count := r.DB.First(&staff, input.ID).RowsAffected; count == 0 {
 		return nil, gqlerror.Errorf("対象のレコードは存在しません")
 	}
 
@@ -133,12 +133,65 @@ func (r *queryResolver) Staffs(ctx context.Context) ([]*model.Staff, error) {
 		return nil, gqlerror.Errorf("情報を取得できませんでした")
 	}
 
-	var _staffs []*model.Staff
+	var result []*model.Staff
 	for _, staff := range staffs {
-		_staffs = append(_staffs, model.StaffFromEntity(&staff))
+		result = append(result, model.StaffFromEntity(&staff))
 	}
 
-	return _staffs, nil
+	return result, nil
+}
+
+func (r *queryResolver) StaffList(ctx context.Context, page *int, per *int) (*model.StaffList, error) {
+	// panic(fmt.Errorf("not implemented"))
+	var lm, pg int
+	if per == nil {
+		lm = 25
+	} else {
+		lm = *per
+	}
+
+	if page == nil {
+		pg = 1
+	} else {
+		pg = *page
+	}
+
+	offset := lm * (pg - 1)
+
+	var staffAll []entity.Staff
+	if err := r.DB.Find(&staffAll).Error; err != nil {
+		return nil, gqlerror.Errorf("情報を取得できませんでした")
+	}
+
+	var staffs []entity.Staff
+	if err := r.DB.Limit(lm).Offset(offset).Find(&staffs).Error; err != nil {
+		return nil, gqlerror.Errorf("情報を取得できませんでした")
+	}
+
+	var result []*model.Staff
+	for _, staff := range staffs {
+		result = append(result, model.StaffFromEntity(&staff))
+	}
+
+	rc := len(staffAll)
+	pa := rc / lm
+	if pb := rc % lm; pb > 0 {
+		pa = pa + 1
+	}
+
+	pageInfo := &model.PageInfo{
+		CurrentPage: pg,
+		RecordCount: rc,
+		PageCount:   pa,
+		Limit:       lm,
+	}
+
+	data := &model.StaffList{
+		PageInfo: pageInfo,
+		Staffs:   result,
+	}
+
+	return data, nil
 }
 
 func (r *queryResolver) Staff(ctx context.Context, id string) (*model.Staff, error) {


### PR DESCRIPTION
## 概要
User APIのスキーマ仕様に合わせてStaff APIのスキーマを調整し、一覧にページネーション用のQueryを設定

## 変更点
- [x] Query: `deleteStaff` 及び `deleteStaffIcon` の引数を `id` 直接指定から `input` 型に変更
- [x] Query に `staffList` を追加し、 offset / limit型のページネーションを実装

## 未変更
- [ ] DB用エンティティの方にStaff関連のDB操作 function / method をまとめる
- [ ] スキーマに対するテスト記述