### PR TITLE
Refactoring/staff api models

### DIFF
--- a/.github/workflows/inquiry_api_test.yml
+++ b/.github/workflows/inquiry_api_test.yml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   test-inquiry-api:
+    name: Test Inquiry API
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/staff_api_test.yml
+++ b/.github/workflows/staff_api_test.yml
@@ -43,7 +43,7 @@ jobs:
         run: go mod download
 
       - name: Test code
-        run: go test -v .
+        run: go test -v ./...
         env:
           DB_HOST: db
           DB_USER: postgres
@@ -52,4 +52,4 @@ jobs:
           GO_ENV: test
 
       - name: Try Building
-        run: go build -o main.go
+        run: go build main.go

--- a/.github/workflows/staff_api_test.yml
+++ b/.github/workflows/staff_api_test.yml
@@ -1,0 +1,55 @@
+name: Staff API Test
+
+on:
+  workflow_dispatch:
+
+  push:
+    paths:
+      - "staff_api/**"
+
+defaults:
+  run:
+    working-directory: ./staff_api
+
+jobs:
+  test-staff-api:
+    name: Test Staff API
+    runs-on: ubuntu-latest
+    env:
+      GO_ENV: production
+      GO111MODULE: on
+      CGO_ENABLED: 0
+      GOOS: linux
+
+    services:
+      db:
+        image: postgres:13.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: db
+          POSTGRES_HOST_AUTH_METHOD: trust
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17.1"
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Test code
+        run: go test -v .
+        env:
+          DB_HOST: db
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+          DB_PORT: 5432
+          GO_ENV: test
+
+      - name: Try Building
+        run: go build -o main.go

--- a/.github/workflows/user_api_test.yml
+++ b/.github/workflows/user_api_test.yml
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   test-user-api:
+    name: Test User API
     runs-on: ubuntu-latest
 
     services:

--- a/client/components/globalStateProvider.tsx
+++ b/client/components/globalStateProvider.tsx
@@ -13,6 +13,7 @@ import Loader from "react-loader-spinner";
 import { generateSessionData, AuthResponseData } from "../modules/jwt";
 import { useSnackbar } from "notistack";
 import { useGetStaffbyEmailQuery } from "../graphql/client";
+import Box from "@mui/material/Box";
 
 const fetchRefreshToken = (token: string) => {
   const url = `${process.env.NEXT_PUBLIC_API_HOST}/api/refresh_token`;
@@ -53,6 +54,7 @@ const GlobalStateProvider: FC = ({ children }) => {
     setLoading(true);
     if (!jwt) {
       router.replace("/login");
+      enqueueSnackbar("ログインしてください", { variant: "error" });
     } else {
       fetchRefreshToken(jwt)
         .then((response) => {
@@ -83,6 +85,7 @@ const GlobalStateProvider: FC = ({ children }) => {
     const id = setInterval(() => {
       if (!jwt) {
         router.replace("/login");
+        enqueueSnackbar("ログインしてください", { variant: "error" });
       } else {
         fetchRefreshToken(jwt)
           .then((response) => {
@@ -103,7 +106,9 @@ const GlobalStateProvider: FC = ({ children }) => {
 
   return (
     <>
-      {children}
+      <Box sx={{ m: 0, p: 0, visibility: currentStaff ? "visible" : "hidden" }}>
+        {children}
+      </Box>
       {loading && (
         <Backdrop open={loading}>
           <Loader type="MutatingDots" height={100} width={100} />

--- a/staff_api/database/postgres.go
+++ b/staff_api/database/postgres.go
@@ -3,7 +3,6 @@ package database
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"gorm.io/driver/postgres"
@@ -72,10 +71,7 @@ func connect(m *Meta) (*gorm.DB, error) {
 }
 
 func connectOrCreatePostgresDatabase(m *Meta) (*gorm.DB, error) {
-	public, err := gorm.Open(postgres.Open(m.PgDsnWithoutDBName()), &gorm.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
+	public, _ := gorm.Open(postgres.Open(m.PgDsnWithoutDBName()), &gorm.Config{})
 	public.Exec(fmt.Sprintf("CREATE DATABASE %s;", m.dbname))
 
 	named, err := gorm.Open(postgres.Open(m.PgDsn()), &gorm.Config{})

--- a/staff_api/database/postgres.go
+++ b/staff_api/database/postgres.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"os"
 
-	"staff_api/entity"
-
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -27,18 +25,13 @@ type Meta struct {
 func Connect() (*gorm.DB, error) {
 	m := Meta{}
 	m.Init()
-	db, err := connect(&m)
 
+	db, err := connect(&m)
 	if err != nil {
 		return nil, err
 	}
 
 	d = db
-
-	err = db.AutoMigrate(&entity.Staff{})
-	if err != nil {
-		return nil, err
-	}
 
 	return db, nil
 }

--- a/staff_api/entity/staff.go
+++ b/staff_api/entity/staff.go
@@ -226,6 +226,19 @@ func (s *Staff) ChangePassword(id string, current string, new string) error {
 	return nil
 }
 
+func (s Staff) IsAuthenticated(email string, password string) bool {
+	err := s.FindStaffByEmail(email)
+	if err != nil {
+		return false
+	}
+
+	if s.comparePassword(password) != nil {
+		return false
+	}
+
+	return true
+}
+
 func (s Staff) comparePassword(p string) error {
 	if bcrypt.CompareHashAndPassword(s.PasswordDigest, []byte(p)) != nil {
 		return errors.New("パスワードが正しくありません")

--- a/staff_api/entity/staff.go
+++ b/staff_api/entity/staff.go
@@ -1,7 +1,13 @@
 package entity
 
 import (
+	"errors"
+	"regexp"
 	"time"
+
+	"staff_api/database"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 type Staff struct {
@@ -12,4 +18,228 @@ type Staff struct {
 	Email          string    `gorm:"uniqueIndex;not null"`
 	PasswordDigest []byte    `gorm:"not null"`
 	Icon           string    `gorm:"type:text"`
+}
+
+type PageInfo struct {
+	CurrentPage  int
+	RecordsCount int
+	PagesCount   int
+	Limit        int
+}
+
+func AllStaffs() ([]Staff, error) {
+	db := database.GetDB()
+
+	var staffs []Staff
+	if err := db.Order("id").Find(&staffs).Error; err != nil {
+		return nil, err
+	}
+
+	return staffs, nil
+}
+
+func PaginatedStaffs(lm int, of int) ([]Staff, error) {
+	db := database.GetDB()
+
+	var staffs []Staff
+	if err := db.Order("id").Limit(lm).Offset(of).Find(&staffs).Error; err != nil {
+		return nil, err
+	}
+
+	return staffs, nil
+}
+
+func GetPageInfo(per int, page int) (*PageInfo, error) {
+	staffs, err := AllStaffs()
+	if err != nil {
+		return nil, err
+	}
+
+	rc := len(staffs)
+	pa := rc / per
+	if pb := rc % per; pb > 0 {
+		pa = pa + 1
+	}
+
+	return &PageInfo{
+		CurrentPage:  page,
+		RecordsCount: rc,
+		PagesCount:   pa,
+		Limit:        per,
+	}, nil
+}
+
+func (s *Staff) FindStaffByID(id string) error {
+	db := database.GetDB()
+	result := db.First(s, id)
+
+	if count := result.RowsAffected; count == 0 {
+		return errors.New("対象のレコードは存在しません")
+	}
+
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) FindStaffByEmail(email string) error {
+	db := database.GetDB()
+	result := db.Where(Staff{Email: email}).First(s)
+
+	if count := result.RowsAffected; count == 0 {
+		return errors.New("対象のレコードは存在しません")
+	}
+
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) Create(name string, email string, password string) error {
+	if isInvalidEmail(email) {
+		return errors.New("Emailの形式が正しくありません")
+	}
+
+	if isInvalidPassword(password) {
+		return errors.New("パスワードは英数字8文字以上である必要があります")
+	}
+
+	db := database.GetDB()
+
+	if count := db.Where("email = ?", email).Find(&Staff{}).RowsAffected; count > 0 {
+		return errors.New("すでに同じEmailが登録されています")
+	}
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte(password), 10)
+	if err != nil {
+		return err
+	}
+
+	s.Name = name
+	s.Email = email
+	s.PasswordDigest = hashed
+
+	if err := db.Create(s).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) Update(id string, name *string, email *string) error {
+	if err := s.FindStaffByID(id); err != nil {
+		return err
+	}
+
+	if name == nil && email == nil {
+		return nil
+	}
+
+	params := map[string]interface{}{}
+
+	if name != nil {
+		params["name"] = *name
+	}
+
+	if email != nil {
+		if isInvalidEmail(*email) {
+			return errors.New("Emailの形式が正しくありません")
+		}
+
+		params["email"] = *email
+	}
+
+	db := database.GetDB()
+	if err := db.Model(s).Updates(params).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) Delete(id string) error {
+	if err := s.FindStaffByID(id); err != nil {
+		return err
+	}
+
+	db := database.GetDB()
+	if err := db.Delete(s, id).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) UpdateIcon(id string, icon string) error {
+	if err := s.FindStaffByID(id); err != nil {
+		return err
+	}
+
+	db := database.GetDB()
+	if err := db.Model(s).Update("icon", icon).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) DeleteIcon(id string) error {
+	if err := s.FindStaffByID(id); err != nil {
+		return err
+	}
+
+	db := database.GetDB()
+	if err := db.Model(s).Update("icon", nil).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Staff) ChangePassword(id string, current string, new string) error {
+	if err := s.FindStaffByID(id); err != nil {
+		return err
+	}
+
+	if err := s.comparePassword(current); err != nil {
+		return err
+	}
+
+	if isInvalidPassword(new) {
+		return errors.New("パスワードは英数字8文字以上である必要があります")
+	}
+
+	newHash, err := bcrypt.GenerateFromPassword([]byte(new), 10)
+	if err != nil {
+		return err
+	}
+
+	db := database.GetDB()
+	if err := db.Model(s).Update("password_digest", newHash).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s Staff) comparePassword(p string) error {
+	if bcrypt.CompareHashAndPassword(s.PasswordDigest, []byte(p)) != nil {
+		return errors.New("パスワードが正しくありません")
+	}
+
+	return nil
+}
+
+func isInvalidEmail(e string) bool {
+	var r = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	return !r.MatchString(e)
+}
+
+func isInvalidPassword(p string) bool {
+	var r = regexp.MustCompile("^[a-zA-Z0-9]{8,}$")
+	return !r.MatchString(p)
 }

--- a/staff_api/entity/staff.go
+++ b/staff_api/entity/staff.go
@@ -39,6 +39,14 @@ func AllStaffs() ([]Staff, error) {
 }
 
 func PaginatedStaffs(lm int, of int) ([]Staff, error) {
+	if lm < 0 {
+		return nil, errors.New("表示件数は0以上である必要があります")
+	}
+
+	if of < 0 {
+		return nil, errors.New("ページ数は1以上である必要があります")
+	}
+
 	db := database.GetDB()
 
 	var staffs []Staff
@@ -50,6 +58,14 @@ func PaginatedStaffs(lm int, of int) ([]Staff, error) {
 }
 
 func GetPageInfo(per int, page int) (*PageInfo, error) {
+	if per < 0 {
+		return nil, errors.New("表示件数は0以上である必要があります")
+	}
+
+	if page < 1 {
+		return nil, errors.New("ページ数は1以上である必要があります")
+	}
+
 	staffs, err := AllStaffs()
 	if err != nil {
 		return nil, err
@@ -100,6 +116,10 @@ func (s *Staff) FindStaffByEmail(email string) error {
 }
 
 func (s *Staff) Create(name string, email string, password string) error {
+	if isInvalidName(name) {
+		return errors.New("名前は必須です")
+	}
+
 	if isInvalidEmail(email) {
 		return errors.New("Emailの形式が正しくありません")
 	}
@@ -131,10 +151,6 @@ func (s *Staff) Create(name string, email string, password string) error {
 }
 
 func (s *Staff) Update(id string, name *string, email *string) error {
-	if err := s.FindStaffByID(id); err != nil {
-		return err
-	}
-
 	if name == nil && email == nil {
 		return nil
 	}
@@ -142,6 +158,10 @@ func (s *Staff) Update(id string, name *string, email *string) error {
 	params := map[string]interface{}{}
 
 	if name != nil {
+		if isInvalidName(*name) {
+			return errors.New("名前は必須です")
+		}
+
 		params["name"] = *name
 	}
 
@@ -151,6 +171,10 @@ func (s *Staff) Update(id string, name *string, email *string) error {
 		}
 
 		params["email"] = *email
+	}
+
+	if err := s.FindStaffByID(id); err != nil {
+		return err
 	}
 
 	db := database.GetDB()
@@ -245,6 +269,10 @@ func (s Staff) comparePassword(p string) error {
 	}
 
 	return nil
+}
+
+func isInvalidName(n string) bool {
+	return len(n) == 0
 }
 
 func isInvalidEmail(e string) bool {

--- a/staff_api/entity/staff_test.go
+++ b/staff_api/entity/staff_test.go
@@ -1,0 +1,376 @@
+package entity
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"staff_api/database"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestMain(m *testing.M) {
+	os.Setenv("GO_ENV", "test")
+	db, err := database.Connect()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	err = db.AutoMigrate(&Staff{})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	code := m.Run()
+
+	cleanStaffs()
+
+	os.Exit(code)
+}
+
+func TestAllStaffs(t *testing.T) {
+	size := 10
+	createStaffs(t, size)
+	defer cleanStaffs()
+
+	staffs, err := AllStaffs()
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, size, len(staffs))
+}
+
+func TestPaginatedStaffs(t *testing.T) {
+	createStaffs(t, 30)
+	defer cleanStaffs()
+
+	limit := 25
+	offset := 0
+	staffs, err := PaginatedStaffs(limit, offset)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, limit, len(staffs))
+
+	offset = 25
+	staffs, err = PaginatedStaffs(limit, offset)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, 5, len(staffs))
+
+	limit = -2
+	offset = 0
+	_, err = PaginatedStaffs(limit, offset)
+
+	assert.Error(t, err)
+
+	limit = 25
+	offset = -1
+	_, err = PaginatedStaffs(limit, offset)
+
+	assert.Error(t, err)
+}
+
+func TestGetPageInfo(t *testing.T) {
+	createStaffs(t, 30)
+	defer cleanStaffs()
+
+	per := 25
+	page := 1
+	info, err := GetPageInfo(per, page)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, PageInfo{
+		CurrentPage:  1,
+		RecordsCount: 30,
+		PagesCount:   2,
+		Limit:        25,
+	}, *info)
+
+	per = 10
+	info, err = GetPageInfo(per, page)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, PageInfo{
+		CurrentPage:  1,
+		RecordsCount: 30,
+		PagesCount:   3,
+		Limit:        10,
+	}, *info)
+
+	page = 3
+	info, err = GetPageInfo(per, page)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, PageInfo{
+		CurrentPage:  3,
+		RecordsCount: 30,
+		PagesCount:   3,
+		Limit:        10,
+	}, *info)
+
+	per = -1
+	_, err = GetPageInfo(per, page)
+
+	assert.Error(t, err)
+
+	per = 25
+	page = -1
+	_, err = GetPageInfo(per, page)
+
+	assert.Error(t, err)
+}
+
+func TestFindStaffByID(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	var staff Staff
+	staff.FindStaffByID(fmt.Sprintf("%d", s.ID))
+
+	assert.Equal(t, s.PasswordDigest, staff.PasswordDigest)
+
+	staff = Staff{}
+	err := staff.FindStaffByID("0")
+
+	assert.Error(t, err)
+}
+
+func TestFindStaffByEmail(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	var staff Staff
+	staff.FindStaffByEmail(s.Email)
+
+	assert.Equal(t, s.PasswordDigest, staff.PasswordDigest)
+
+	staff = Staff{}
+	err := staff.FindStaffByEmail("test")
+
+	assert.Error(t, err)
+}
+
+func TestCreate(t *testing.T) {
+	defer cleanStaffs()
+
+	var staff Staff
+
+	name := "テスト"
+	email := "test100000@example.com"
+	password := "password"
+	bs := getRecordSize()
+	staff.Create(name, email, password)
+
+	assert.Equal(t, bs+1, getRecordSize())
+
+	staff = Staff{}
+	name = ""
+	err := staff.Create(name, email, password)
+
+	assert.Error(t, err)
+
+	staff = Staff{}
+	name = "テスト"
+	email = "test100000"
+	err = staff.Create(name, email, password)
+
+	assert.Error(t, err)
+
+	staff = Staff{}
+	email = "test100000@example.com"
+	password = "pass"
+	err = staff.Create(name, email, password)
+
+	assert.Error(t, err)
+}
+
+func TestUpdate(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	id := fmt.Sprintf("%d", s.ID)
+
+	var staff Staff
+
+	name := "テスト"
+	email := "test100000@example.com"
+	staff.Update(id, &name, &email)
+
+	assert.Equal(t, email, staff.Email)
+
+	var fs Staff
+	database.GetDB().First(&fs, id)
+
+	assert.Equal(t, email, fs.Email)
+
+	name = ""
+	err := staff.Update(id, &name, &email)
+
+	assert.Error(t, err)
+
+	name = "テスト"
+	email = "test100000"
+	err = staff.Update(id, &name, &email)
+
+	assert.Error(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	var staff Staff
+
+	id := "0"
+	err := staff.Delete(id)
+
+	assert.Error(t, err)
+
+	id = fmt.Sprintf("%d", s.ID)
+	staff = Staff{}
+	staff.Delete(id)
+
+	assert.Equal(t, int64(0), database.GetDB().First(&Staff{}, s.ID).RowsAffected)
+}
+
+func TestChangeIcon(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	id := fmt.Sprintf("%d", s.ID)
+
+	var staff Staff
+	iconStr := "testimagestring"
+	staff.UpdateIcon(id, iconStr)
+
+	assert.Equal(t, iconStr, staff.Icon)
+
+	var fs Staff
+	database.GetDB().First(&fs, id)
+
+	assert.Equal(t, iconStr, fs.Icon)
+
+	staff = Staff{}
+	staff.DeleteIcon(id)
+
+	assert.Equal(t, "", staff.Icon)
+
+	fs = Staff{}
+	database.GetDB().First(&fs, id)
+
+	assert.Equal(t, "", fs.Icon)
+}
+
+func TestChangePassword(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	id := fmt.Sprintf("%d", s.ID)
+
+	var staff Staff
+	cps := "password"
+	nps := "newpassword"
+	staff.ChangePassword(id, cps, nps)
+
+	assert.Equal(
+		t,
+		nil,
+		bcrypt.CompareHashAndPassword(staff.PasswordDigest, []byte(nps)),
+	)
+
+	var fs Staff
+	database.GetDB().First(&fs, id)
+
+	assert.Equal(
+		t,
+		nil,
+		bcrypt.CompareHashAndPassword(fs.PasswordDigest, []byte(nps)),
+	)
+
+	staff = Staff{}
+	cps = nps
+	nps = "pass"
+	err := staff.ChangePassword(id, cps, nps)
+
+	assert.Error(t, err)
+}
+
+func TestIsAuthenticated(t *testing.T) {
+	s := createStaff(t)
+	defer cleanStaffs()
+
+	e := s.Email
+	p := "password"
+
+	var staff Staff
+	assert.Equal(t, true, staff.IsAuthenticated(e, p))
+
+	staff = Staff{}
+	p = "incorrectpassword"
+	assert.Equal(t, false, staff.IsAuthenticated(e, p))
+}
+
+var staffCreatedTimes = 1000
+
+func createStaff(t *testing.T) Staff {
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password"), 10)
+	staff := Staff{
+		Name:           fmt.Sprintf("テスト%d", staffCreatedTimes),
+		Email:          fmt.Sprintf("test%d@example.com", staffCreatedTimes),
+		PasswordDigest: hashed,
+	}
+
+	if err := database.GetDB().Create(&staff).Error; err != nil {
+		log.Fatal(err)
+	}
+
+	staffCreatedTimes++
+
+	return staff
+}
+
+func createStaffs(t *testing.T, size int) []Staff {
+	cleanStaffs()
+	if size < 1 {
+		return []Staff{}
+	}
+
+	var staffs []Staff
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password"), 10)
+	for i := 1; i <= size; i++ {
+		staffs = append(staffs, Staff{
+			Name:           fmt.Sprintf("テスト%d", i),
+			Email:          fmt.Sprintf("test%d@example.com", i),
+			PasswordDigest: hashed,
+		})
+	}
+
+	if err := database.GetDB().Create(&staffs).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	return staffs
+}
+
+func getRecordSize() int64 {
+	var staffs []Staff
+	return database.GetDB().Find(&staffs).RowsAffected
+}
+
+func cleanStaffs() {
+	database.GetDB().Exec("DELETE FROM staffs")
+}

--- a/staff_api/go.mod
+++ b/staff_api/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/99designs/gqlgen v0.14.0
+	github.com/stretchr/testify v1.7.0
 	github.com/vektah/gqlparser/v2 v2.2.0
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
 	google.golang.org/grpc v1.41.0
@@ -14,6 +15,7 @@ require (
 
 require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -29,9 +31,11 @@ require (
 	github.com/jinzhu/now v1.1.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/staff_api/go.sum
+++ b/staff_api/go.sum
@@ -131,9 +131,11 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -326,6 +328,7 @@ google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+Rur
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=

--- a/staff_api/graph/entity.resolvers.go
+++ b/staff_api/graph/entity.resolvers.go
@@ -15,8 +15,8 @@ import (
 
 func (r *entityResolver) FindStaffByID(ctx context.Context, id string) (*model.Staff, error) {
 	var staff entity.Staff
-	if count := r.DB.First(&staff, id).RowsAffected; count == 0 {
-		return nil, gqlerror.Errorf("対象のレコードは存在しません")
+	if err := staff.FindStaffByID(id); err != nil {
+		return nil, gqlerror.Errorf(err.Error())
 	}
 
 	return model.StaffFromEntity(&staff), nil

--- a/staff_api/main.go
+++ b/staff_api/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"staff_api/database"
+	"staff_api/entity"
 	"staff_api/server"
 )
 
@@ -14,6 +15,11 @@ func main() {
 	}
 
 	db, err := database.Connect()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = db.AutoMigrate(&entity.Staff{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/staff_api/main.go
+++ b/staff_api/main.go
@@ -14,13 +14,9 @@ func main() {
 		os.Setenv("GO_ENV", "development")
 	}
 
-	db, err := database.Connect()
-	if err != nil {
-		log.Fatal(err)
-	}
+	db, _ := database.Connect()
 
-	err = db.AutoMigrate(&entity.Staff{})
-	if err != nil {
+	if err := db.AutoMigrate(&entity.Staff{}); err != nil {
 		log.Fatal(err)
 	}
 

--- a/staff_api/server/grpc.go
+++ b/staff_api/server/grpc.go
@@ -5,11 +5,9 @@ import (
 	"log"
 	"net"
 
-	"staff_api/database"
 	"staff_api/entity"
 	"staff_api/proto"
 
-	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 )
 
@@ -23,18 +21,9 @@ func (*gsv) Authenticate(ctx context.Context, req *proto.AuthenticateRequest) (*
 	email := req.GetEmail()
 	password := req.GetPassword()
 
-	authenticated := false
 	var staff entity.Staff
-	db := database.GetDB()
-	if count := db.First(&staff, entity.Staff{Email: email}).RowsAffected; count > 0 {
-		err := bcrypt.CompareHashAndPassword(staff.PasswordDigest, []byte(password))
-		if err == nil {
-			authenticated = true
-		}
-	}
-
 	return &proto.AuthenticateResponse{
-		Authenticated: authenticated,
+		Authenticated: staff.IsAuthenticated(email, password),
 	}, nil
 }
 


### PR DESCRIPTION
## 概要

StaffAPIにて、graph/resolvers.go内に記述していたロジックをentity/staff.goに逃した。

それに合わせてモデルテストを記述＆GithubActionsのワークフローを追加

## 実装した機能

- [x] Fat resolver から Fat model に変更
- [x] entity.Staffに対するテストを記述
- [x] 上記テストをプッシュ時に実行するワークフローを追加