### PR TITLE
Feature/create resolvers test for inquiry api

### DIFF
--- a/inquiry_api/app/graphql/app_schema.rb
+++ b/inquiry_api/app/graphql/app_schema.rb
@@ -18,6 +18,18 @@ class AppSchema < GraphQL::Schema
     )
   end
 
+  rescue_from(ActiveRecord::RecordNotFound) do |error|
+    GraphQL::ExecutionError.new(
+      I18n.t(:record_not_found, scope: %i[activerecord errors messages]),
+      extensions: {
+        code: 'RECORD_NOT_FOUND',
+        record: {
+          model: error.model
+        }
+      }
+    )
+  end
+
   # Union and Interface Resolution
   def self.resolve_type(_abstract_type, _obj, _ctx)
     # TODO: Implement this function

--- a/inquiry_api/app/graphql/mutations/change_progress_recontacted_on.rb
+++ b/inquiry_api/app/graphql/mutations/change_progress_recontacted_on.rb
@@ -7,7 +7,8 @@ module Mutations
 
     def resolve(id:, recontacted_on: nil)
       progress = Progress.find id
-      progress.update!(recontacted_on: Date.parse(recontacted_on)) && progress
+      progress.asign_recontacted_on! recontacted_on
+      progress
     end
   end
 end

--- a/inquiry_api/app/graphql/mutations/change_progress_state.rb
+++ b/inquiry_api/app/graphql/mutations/change_progress_state.rb
@@ -8,6 +8,9 @@ module Mutations
     def resolve(id:, event:)
       progress = Progress.find id
       progress.send event
+
+      raise ActiveRecord::RecordInvalid, progress if progress.errors.present?
+
       progress.save! && progress
     end
   end

--- a/inquiry_api/app/graphql/mutations/change_progress_state.rb
+++ b/inquiry_api/app/graphql/mutations/change_progress_state.rb
@@ -7,8 +7,6 @@ module Mutations
 
     def resolve(id:, event:)
       progress = Progress.find id
-      progress.errors.add :base, I18n.t('errors.aasm.invalid_event') unless progress.send("may_#{event}?")
-
       progress.send event
       progress.save! && progress
     end

--- a/inquiry_api/app/graphql/mutations/create_menu.rb
+++ b/inquiry_api/app/graphql/mutations/create_menu.rb
@@ -5,9 +5,12 @@ module Mutations
 
     type Types::MenuType
 
-    def resolve(name:, published_on:)
-      Menu.create! name: name,
-                   published_on: Date.parse(published_on)
+    def resolve(**args)
+      menu = Menu.new name: args[:name]
+      unless args.key?(:published_on)
+        menu.published_on = (Date.parse(args[:published_on]) if args[:published_on].present?)
+      end
+      menu.save! && menu
     end
   end
 end

--- a/inquiry_api/app/graphql/types/query_type.rb
+++ b/inquiry_api/app/graphql/types/query_type.rb
@@ -7,17 +7,21 @@ module Types
       argument :inquiry_id, Int, required: false
       argument :order, String, required: false
     end
-    def comments(inquiry_id: nil, order: 'created_at desc')
-      Comment.inquiry_id_eq(inquiry_id).order order.underscore
+    def comments(inquiry_id: nil, order: nil)
+      Comment.inquiry_id_eq(inquiry_id)
+             .order(order.present? ? order.underscore : 'id desc')
     end
 
     field :comments_list, CommentsListType, null: false do
       argument :page, Int, required: false
       argument :per, Int, required: false
+      argument :inquiry_id, Int, required: false
       argument :order, String, required: false
     end
-    def comments_list(page: 1, per: 25, order: 'created_at desc')
-      result = Comment.all.order(order.underscore).page(page).per(per)
+    def comments_list(page: 1, per: 25, inquiry_id: nil, order: nil)
+      result = Comment.inquiry_id_eq(inquiry_id)
+                      .order(order.present? ? order.underscore : 'id desc')
+                      .page(page).per(per)
       parse_connection_payload result, :comments
     end
 
@@ -32,13 +36,13 @@ module Types
       argument :order, String, required: false
       argument :fields_cont, String, required: false
       argument :staff_id, Int, required: false
+      argument :state, ProgressStateEnum, required: false
     end
-    def inquiries(fields_cont: nil, staff_id: nil, order: 'created_at desc')
-      Inquiry.all.then do |r|
-        fields_cont.present? ? r.fields_cont(fields_cont) : r
-      end.then do |r|
-        staff_id.present? ? r.includes(:progress).where(progress: { staff_id: staff_id }) : r
-      end.order order.underscore
+    def inquiries(fields_cont: nil, staff_id: nil, state: nil, order: nil)
+      Inquiry.fields_cont(fields_cont)
+             .state_eq(state)
+             .staff_eq(staff_id)
+             .order(order.present? ? order.underscore : 'id desc')
     end
 
     field :inquiries_list, InquiriesListType, null: false do
@@ -49,12 +53,11 @@ module Types
       argument :staff_id, Int, required: false
       argument :state, ProgressStateEnum, required: false
     end
-    def inquiries_list(page: 1, per: 25, fields_cont: nil, staff_id: nil, order: 'created_at desc', state: nil)
-      result = Inquiry.joins(:progress)
-                      .fields_cont(fields_cont)
+    def inquiries_list(page: 1, per: 25, fields_cont: nil, staff_id: nil, order: nil, state: nil)
+      result = Inquiry.fields_cont(fields_cont)
                       .state_eq(state)
                       .staff_eq(staff_id)
-                      .order(order.underscore)
+                      .order(order.present? ? order.underscore : 'id desc')
                       .page(page)
                       .per(per)
       parse_connection_payload result, :inquiries
@@ -70,8 +73,8 @@ module Types
     field :menus, [MenuType], null: false do
       argument :order, String, required: false
     end
-    def menus(order: 'created_at desc')
-      Menu.all.order order.underscore
+    def menus(order: nil)
+      Menu.all.order(order.present? ? order.underscore : 'id desc')
     end
 
     field :menus_list, MenusListType, null: false do
@@ -79,8 +82,8 @@ module Types
       argument :per, Int, required: false
       argument :order, String, required: false
     end
-    def menus_list(page: 1, per: 25, order: 'created_at desc')
-      result = Menu.all.order(order.underscore).page(page).per(per)
+    def menus_list(page: 1, per: 25, order: nil)
+      result = Menu.all.order(order.present? ? order.underscore : 'id desc').page(page).per(per)
       parse_connection_payload result, :menus
     end
 
@@ -97,14 +100,11 @@ module Types
       argument :state, ProgressStateEnum, required: false
       argument :staff_id, Int, required: false
     end
-    def progresses(rank: nil, state: nil, staff_id: nil, order: 'created_at desc')
-      Progress.all.then do |r|
-        rank.present? && r.respond_to?(rank) ? r.send(rank) : r
-      end.then do |r|
-        state.present? && r.respond_to?(state) ? r.send(state) : r
-      end.then do |r|
-        staff_id.present? ? r.where(staff_id: staff_id) : r
-      end.order order.underscore
+    def progresses(rank: nil, state: nil, staff_id: nil, order: nil)
+      Progress.rank_eq(rank)
+              .state_eq(state)
+              .staff_eq(staff_id)
+              .order(order.present? ? order.underscore : 'id desc')
     end
 
     field :progresses_list, ProgressesListType, null: false do
@@ -115,14 +115,12 @@ module Types
       argument :state, ProgressStateEnum, required: false
       argument :staff_id, Int, required: false
     end
-    def progresses_list(page: 1, per: 25, rank: nil, state: nil, staff_id: nil, order: 'created_at desc')
-      result = Progress.all.then do |r|
-        rank.present? && r.respond_to?(rank) ? r.send(rank) : r
-      end.then do |r|
-        state.present? && r.respond_to?(state) ? r.send(state) : r
-      end.then do |r|
-        staff_id.present? ? r.where(staff_id: staff_id) : r
-      end.order(order.underscore).page(page).per(per)
+    def progresses_list(page: 1, per: 25, rank: nil, state: nil, staff_id: nil, order: nil)
+      result = Progress.rank_eq(rank)
+                       .state_eq(state)
+                       .staff_eq(staff_id)
+                       .order(order.present? ? order.underscore : 'id desc')
+                       .page(page).per(per)
       parse_connection_payload result, :progresses
     end
 

--- a/inquiry_api/app/models/inquiry.rb
+++ b/inquiry_api/app/models/inquiry.rb
@@ -53,6 +53,8 @@ class Inquiry < ApplicationRecord
   }
 
   scope :fields_cont, lambda { |word|
+    return all if word.blank?
+
     company_name_cont(word)
       .or(name_cont(word))
       .or(email_cont(word))
@@ -61,13 +63,13 @@ class Inquiry < ApplicationRecord
   scope :state_eq, lambda { |state|
     return all if state.blank?
 
-    merge Progress.send(state.to_s)
+    joins(:progress).merge Progress.state_eq(state)
   }
 
   scope :staff_eq, lambda { |staff_id|
     return all if staff_id.blank?
 
-    merge Progress.where(staff_id: staff_id)
+    joins(:progress).merge Progress.staff_eq(staff_id)
   }
 
   private

--- a/inquiry_api/app/models/progress.rb
+++ b/inquiry_api/app/models/progress.rb
@@ -133,6 +133,5 @@ class Progress < ApplicationRecord
     message = I18n.t :status_denied,
                      scope: %i[activerecord errors messages]
     errors.add :base, message
-    raise ActiveRecord::RecordInvalid, self
   end
 end

--- a/inquiry_api/app/models/progress.rb
+++ b/inquiry_api/app/models/progress.rb
@@ -25,11 +25,14 @@ class Progress < ApplicationRecord
 
   attr_reader :event_log
 
-  before_validation :clear_recontacted_on
-
   belongs_to :inquiry
 
   enum rank: { d: 0, c: 1, b: 2, a: 3 }
+
+  validates :staff_id, numericality: {
+    integer: true,
+    greater_than: 0
+  }, allow_nil: true
 
   aasm column: :state do
     state :waiting, initial: true
@@ -68,6 +71,24 @@ class Progress < ApplicationRecord
     end
   end
 
+  scope :rank_eq, lambda { |value|
+    return all if value.blank?
+
+    send value
+  }
+
+  scope :state_eq, lambda { |value|
+    return all if value.blank?
+
+    send value
+  }
+
+  scope :staff_eq, lambda { |staff_id|
+    return all if staff_id.blank?
+
+    where staff_id: staff_id
+  }
+
   def state_i18n
     I18n.t state.to_sym,
            scope: %i[activerecord attributes progress state]
@@ -81,6 +102,17 @@ class Progress < ApplicationRecord
     end
   end
 
+  def asign_recontacted_on!(date)
+    if waiting_recontact?
+      update! recontacted_on: Date.parse(date)
+    else
+      message = I18n.t :present,
+                       scope: %i[errors messages]
+      errors.add :recontacted_on, message
+      raise ActiveRecord::RecordInvalid, self
+    end
+  end
+
   private
 
   def event_i18n(event)
@@ -89,6 +121,8 @@ class Progress < ApplicationRecord
   end
 
   def state_changed
+    self.recontacted_on = nil unless aasm.to_state != :waiting_recontact?
+
     message = I18n.t :status_changed,
                      scope: %i[activerecord logs messages],
                      to_state: aasm.to_state
@@ -99,9 +133,6 @@ class Progress < ApplicationRecord
     message = I18n.t :status_denied,
                      scope: %i[activerecord errors messages]
     errors.add :base, message
-  end
-
-  def clear_recontacted_on
-    self.recontacted_on = nil unless waiting_recontact?
+    raise ActiveRecord::RecordInvalid, self
   end
 end

--- a/inquiry_api/config/locales/ja.yml
+++ b/inquiry_api/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
   activerecord:
     errors:
       messages:
+        record_not_found: '対象のレコードは存在しません'
         record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"

--- a/inquiry_api/config/locales/models.ja.yml
+++ b/inquiry_api/config/locales/models.ja.yml
@@ -24,7 +24,7 @@ ja:
         staff_id: スタッフID
         rank: 見込みランク
         contacted_at: 連絡日時
-        reconciled_on: 再連絡日
+        recontacted_on: 再連絡日
         state:
           waiting: 未着手
           waiting_recontact: 再度連絡待ち

--- a/inquiry_api/spec/factories/progresses.rb
+++ b/inquiry_api/spec/factories/progresses.rb
@@ -24,9 +24,8 @@ FactoryBot.define do
   factory :progress do
     association :inquiry
 
-    staff_id { 1 }
-    rank { 0 }
-    contacted_at { nil }
-    recontacted_on { nil }
+    staff_id { [1, 2, 3].sample }
+    rank { %w[a b c d].sample }
+    state { %i[waiting waiting_recontact contacting estimating archived ordered].sample }
   end
 end

--- a/inquiry_api/spec/models/progress_spec.rb
+++ b/inquiry_api/spec/models/progress_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Progress, type: :model do
           { label: I18n.t(event, scope: %i[activerecord attributes progress event]), event: event }
         end
       end
-      let(:progress) { create :progress }
+      let(:progress) { create :progress, state: :waiting }
       it 'order以外のeventが配列で返される' do
         is_asserted_by { progress.selectable_events == events }
       end

--- a/inquiry_api/spec/models/progress_spec.rb
+++ b/inquiry_api/spec/models/progress_spec.rb
@@ -24,7 +24,7 @@ require 'rails_helper'
 
 RSpec.describe Progress, type: :model do
   describe '# aasm_status' do
-    let(:progress) { create :progress }
+    let(:progress) { create :progress, state: :waiting }
     let(:error_message) do
       I18n.t :status_denied,
              scope: %i[activerecord errors messages]

--- a/inquiry_api/spec/requests/graphql/mutations/change_progress_rank_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/change_progress_rank_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::ChangeProgressRank, type: :request do
+  let(:inquiry) { create :inquiry }
+  let(:progress) { inquiry.progress }
+  def input(id, rank)
+    <<~INPUT
+      mutation {
+        changeProgressRank(input: {
+          id: "#{id}",
+          rank: #{rank}
+        }) {
+          id
+          rank
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      result = AppSchema.execute input(progress.id, 'a')
+      is_asserted_by { result.dig('data', 'changeProgressRank', 'rank') == 'a' }
+      is_asserted_by { progress.reload.rank == 'a' }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(0, 'a')
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.rank == 'd' }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/change_progress_recontacted_on_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/change_progress_recontacted_on_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::ChangeProgressRecontactedOn, type: :request do
+  let(:inquiry) { create :inquiry }
+  let(:progress) { inquiry.progress }
+  def input(id, date)
+    <<~INPUT
+      mutation {
+        changeProgressRecontactedOn(input: {
+          id: "#{id}",
+          recontactedOn: "#{date}"
+        }) {
+          id
+          recontactedOn
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      date = '2021-01-01'
+      progress.recontact!
+      result = AppSchema.execute input(progress.id, date)
+      is_asserted_by { result.dig('data', 'changeProgressRecontactedOn', 'recontactedOn') == date }
+      is_asserted_by { progress.reload.recontacted_on == Date.parse(date) }
+    end
+  end
+
+  describe 'state: waiting_recontact以外の状態で値を与えた場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      date = '2021-01-01'
+      result = AppSchema.execute input(progress.id, date)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.recontacted_on.nil? }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(0, '2021-01-01')
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.recontacted_on.nil? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/change_progress_staff_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/change_progress_staff_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::ChangeProgressStaff, type: :request do
+  let(:inquiry) { create :inquiry }
+  let(:progress) { inquiry.progress }
+  let(:current_staff_id) { 1 }
+  before do
+    progress.update staff_id: current_staff_id
+  end
+  def input(id, staff_id)
+    <<~INPUT
+      mutation {
+        changeProgressStaff(input: {
+          id: "#{id}",
+          staffId: #{staff_id}
+        }) {
+          id
+          staffId
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      new_staff_id = current_staff_id + 1
+      result = AppSchema.execute input(progress.id, new_staff_id)
+      is_asserted_by { result.dig('data', 'changeProgressStaff', 'staffId') == new_staff_id }
+      is_asserted_by { progress.reload.staff_id == new_staff_id }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(progress.id, 0)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.staff_id == current_staff_id }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(0, current_staff_id + 1)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.staff_id == current_staff_id }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/change_progress_state_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/change_progress_state_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::ChangeProgressState, type: :request do
+  let(:inquiry) { create :inquiry }
+  let(:progress) { inquiry.progress }
+  def input(id, event)
+    <<~INPUT
+      mutation {
+        changeProgressState(input: {
+          id: "#{id}",
+          event: #{event}
+        }) {
+          id
+          state
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      result = AppSchema.execute input(progress.id, 'contact')
+      is_asserted_by { result.dig('data', 'changeProgressState', 'state') == 'contacting' }
+      is_asserted_by { progress.reload.state == 'contacting' }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(progress.id, 'order')
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.state == 'waiting' }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(0, 'contacting')
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { progress.reload.state == 'waiting' }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/create_comment_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/create_comment_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateComment, type: :request do
+  let(:inquiry) { create :inquiry }
+  let(:comment_attributes) { attributes_for :comment, inquiry_id: inquiry.id }
+  def input(comment)
+    <<~INPUT
+      mutation {
+        createComment(input: {
+          #{comment[:staff_id].present? ? "staffId: #{comment[:staff_id]}," : nil}
+          #{comment[:inquiry_id].present? ? "inquiryId: #{comment[:inquiry_id]}," : nil}
+          content: "#{comment[:content]}"
+        }) {
+          id
+          content
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが作成される' do
+      result = AppSchema.execute input(comment_attributes)
+      is_asserted_by { result.dig('data', 'createComment', 'content') == comment_attributes[:content] }
+      is_asserted_by { Comment.first.content == comment_attributes[:content] }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは作成されない' do
+      result = AppSchema.execute input(comment_attributes.merge({ content: nil }))
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Comment.all.size.zero? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/create_inquiry_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/create_inquiry_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateInquiry, type: :request do
+  let(:inquiry_attributes) { attributes_for :inquiry }
+  let(:progress_attributes) { attributes_for :progress }
+  def input(inquiry, progress)
+    <<~INPUT
+      mutation {
+        createInquiry(input: {
+          #{inquiry[:user_id].present? ? "userId: #{inquiry[:user_id]}," : nil}
+          companyName: "#{inquiry[:company_name]}",
+          name: "#{inquiry[:name]}",
+          email: "#{inquiry[:email]}",
+          tel: "#{inquiry[:tel]}",
+          #{inquiry[:number_of_users].present? ? "numberOfUsers: #{inquiry[:number_of_users]}," : nil}
+          introductoryTerm: "#{inquiry[:introductory_term]}",
+          detail: "#{inquiry[:detail]}",
+          #{inquiry[:menu_ids].present? ? "menuIds: #{inquiry[:menu_ids]}," : nil}
+          progress: {
+            #{progress[:rank].present? ? "rank: #{progress[:rank]}" : nil},
+            #{progress[:staff_id].present? ? "staffId: #{progress[:staff_id]}" : nil},
+          }
+        }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが作成される' do
+      result = AppSchema.execute input(inquiry_attributes, progress_attributes.merge({ rank: 0 }))
+      is_asserted_by { result.dig('data', 'createInquiry', 'name') == inquiry_attributes[:name] }
+      is_asserted_by { Inquiry.first.name == inquiry_attributes[:name] }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは作成されない' do
+      result = AppSchema.execute input(inquiry_attributes.merge({ email: nil }), progress_attributes)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Inquiry.all.size.zero? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/create_menu_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/create_menu_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateMenu, type: :request do
+  let(:menu_attributes) { attributes_for :menu }
+  def input(menu)
+    <<~INPUT
+      mutation {
+        createMenu(input: {
+          name: "#{menu[:name]}"
+        }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが作成される' do
+      result = AppSchema.execute input(menu_attributes)
+      is_asserted_by { result.dig('data', 'createMenu', 'name') == menu_attributes[:name] }
+      is_asserted_by { Menu.first.name == menu_attributes[:name] }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは作成されない' do
+      result = AppSchema.execute input(menu_attributes.merge({ name: nil }))
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Menu.all.size.zero? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/delete_comment_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/delete_comment_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::DeleteComment, type: :request do
+  let(:comment) { create :comment }
+  def input(id)
+    <<~INPUT
+      mutation {
+        deleteComment(input: { id: "#{id}" }) {
+          id
+          content
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが削除される' do
+      result = AppSchema.execute input(comment.id)
+      is_asserted_by { result.dig('data', 'deleteComment', 'content') == comment.content }
+      is_asserted_by { Comment.find_by_id(comment.id).nil? }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは削除されない' do
+      result = AppSchema.execute input(0)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Comment.find(comment.id).present? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/delete_inquiry_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/delete_inquiry_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::DeleteInquiry, type: :request do
+  let(:inquiry) { create :inquiry }
+  def input(id)
+    <<~INPUT
+      mutation {
+        deleteInquiry(input: { id: "#{id}" }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが削除される' do
+      result = AppSchema.execute input(inquiry.id)
+      is_asserted_by { result.dig('data', 'deleteInquiry', 'name') == inquiry.name }
+      is_asserted_by { Inquiry.find_by_id(inquiry.id).nil? }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは削除されない' do
+      result = AppSchema.execute input(0)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Inquiry.find(inquiry.id).present? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/delete_menu_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/delete_menu_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::DeleteMenu, type: :request do
+  let(:menu) { create :menu }
+  def input(id)
+    <<~INPUT
+      mutation {
+        deleteMenu(input: { id: "#{id}" }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが削除される' do
+      result = AppSchema.execute input(menu.id)
+      is_asserted_by { result.dig('data', 'deleteMenu', 'name') == menu.name }
+      is_asserted_by { Menu.find_by_id(menu.id).nil? }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは削除されない' do
+      result = AppSchema.execute input(0)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Menu.find(menu.id).present? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/update_comment_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/update_comment_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateComment, type: :request do
+  let(:comment) { create :comment }
+  let(:comment_attributes) { comment.attributes.symbolize_keys }
+  def input(comment)
+    <<~INPUT
+      mutation {
+        updateComment(input: {
+          #{comment[:id].present? ? "id: #{comment[:id]}," : nil}
+          content: "#{comment[:content]}"
+        }) {
+          id
+          content
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      new_content = 'asserted_text'
+      result = AppSchema.execute input(comment_attributes.merge({ content: new_content }))
+      is_asserted_by { result.dig('data', 'updateComment', 'content') == new_content }
+      is_asserted_by { comment.reload.content == new_content }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      before_content = comment.content
+      result = AppSchema.execute input(comment_attributes.merge({ content: nil }))
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { comment.reload.content == before_content }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(comment_attributes.merge({ id: 0 }))
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Comment.find(comment.id).present? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/update_inquiry_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/update_inquiry_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateInquiry, type: :request do
+  let(:inquiry) { create :inquiry }
+  let(:inquiry_attributes) { inquiry.attributes.symbolize_keys }
+  let(:progress) { create :progress, inquiry: inquiry }
+  let(:progress_attributes) { progress.attributes.symbolize_keys }
+  def input(inquiry, progress)
+    <<~INPUT
+      mutation {
+        updateInquiry(input: {
+          #{inquiry[:id].present? ? "id: #{inquiry[:id]}," : nil}
+          #{inquiry[:user_id].present? ? "userId: #{inquiry[:user_id]}," : nil}
+          companyName: "#{inquiry[:company_name]}",
+          name: "#{inquiry[:name]}",
+          email: "#{inquiry[:email]}",
+          tel: "#{inquiry[:tel]}",
+          #{inquiry[:number_of_users].present? ? "numberOfUsers: #{inquiry[:number_of_users]}," : nil}
+          introductoryTerm: "#{inquiry[:introductory_term]}",
+          detail: "#{inquiry[:detail]}",
+          #{inquiry[:menu_ids].present? ? "menuIds: #{inquiry[:menu_ids]}," : nil}
+          progress: {
+            #{progress[:rank].present? ? "rank: #{progress[:rank]}" : nil},
+            #{progress[:staff_id].present? ? "staffId: #{progress[:staff_id]}" : nil},
+          }
+        }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      new_name = 'asserted_name'
+      result = AppSchema.execute input(inquiry_attributes.merge({ name: new_name }),
+                                       progress_attributes.merge({ rank: 1 }))
+      is_asserted_by { result.dig('data', 'updateInquiry', 'name') == new_name }
+      is_asserted_by { inquiry.reload.name == new_name }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      before_email = inquiry.email
+      result = AppSchema.execute input(inquiry_attributes.merge({ email: nil }), progress_attributes)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { inquiry.reload.email == before_email }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(inquiry_attributes.merge({ id: 0 }), progress_attributes)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Inquiry.find(inquiry.id).present? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/mutations/update_menu_spec.rb
+++ b/inquiry_api/spec/requests/graphql/mutations/update_menu_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateMenu, type: :request do
+  let(:menu) { create :menu }
+  let(:menu_attributes) { menu.attributes.symbolize_keys }
+  def input(menu)
+    <<~INPUT
+      mutation {
+        updateMenu(input: {
+          #{menu[:id].present? ? "id: #{menu[:id]}," : nil}
+          name: "#{menu[:name]}"
+        }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
+      new_name = 'asserted_text'
+      result = AppSchema.execute input(menu_attributes.merge({ name: new_name }))
+      is_asserted_by { result.dig('data', 'updateMenu', 'name') == new_name }
+      is_asserted_by { menu.reload.name == new_name }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      before_name = menu.name
+      result = AppSchema.execute input(menu_attributes.merge({ name: nil }))
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { menu.reload.name == before_name }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      result = AppSchema.execute input(menu_attributes.merge({ id: 0 }))
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { Menu.find(menu.id).present? }
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/query/comment_type_spec.rb
+++ b/inquiry_api/spec/requests/graphql/query/comment_type_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::CommentType, type: :request do
+  before do
+    @model_key = :comment
+    @models_key = @model_key.to_s.downcase.pluralize.camelize(:lower).to_sym
+    @models_list_key = "#{@models_key}List".to_sym
+  end
+
+  describe '単数取得' do
+    let(:record) { create @model_key }
+    let(:query) do
+      <<~QUERY
+        query {
+          #{@model_key}(id: #{record.id}) {
+            id
+          }
+        }
+      QUERY
+    end
+
+    it '指定したレコードが取得できること' do
+      result = AppSchema.execute query
+      res = result.dig 'data', @model_key.to_s
+
+      expect(res).to include(
+        'id' => record.id.to_s
+      )
+    end
+  end
+
+  describe '一覧取得' do
+    let(:inquiry_ids) { create_list(:inquiry, 5).map(&:id) }
+    let(:records) do
+      5.times.map do
+        create @model_key, inquiry_id: inquiry_ids.sample
+      end
+    end
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(inquiry_id: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_key}(#{inquiry_id.present? ? "inquiryId: #{inquiry_id}, " : nil}order: "#{order}") {
+            id
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'レコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids
+        end
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids.reverse
+        end
+      end
+    end
+
+    context 'inquiry_idが与えられた場合' do
+      it 'inquiry_idが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        target_id = inquiry_ids.sample
+        result = AppSchema.execute query(inquiry_id: target_id)
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == Comment.where(inquiry_id: target_id).size }
+      end
+    end
+  end
+
+  describe 'ページネーション' do
+    let(:inquiry_ids) { create_list(:inquiry, 5).map(&:id) }
+    let(:records) do
+      30.times.map do
+        create @model_key, inquiry_id: inquiry_ids.sample
+      end
+    end
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(page: nil, per: nil, inquiry_id: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_list_key}(#{page.present? ? "page: #{page}, " : nil}#{per.present? ? "per: #{per}, " : nil}#{inquiry_id.present? ? "inquiryId: #{inquiry_id}, " : nil}order: "#{order}") {
+            #{@models_key} {
+              id
+            }
+            pageInfo {
+              currentPage
+              pagesCount
+              recordsCount
+              limit
+            }
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'per: 25, page: 1の状態でレコードの一覧がページネーション付きで取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'per / pageが与えられた場合' do
+      it 'レコードの一覧が指定されたlimit / offsetで取得できること' do
+        records
+        result = AppSchema.execute query(per: 20, page: 2)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 10 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[20...30]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids.reverse[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'inquiry_idが与えられた場合' do
+      it 'inquiry_idが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        target_id = inquiry_ids.sample
+        result = AppSchema.execute query(inquiry_id: target_id, per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        len = Comment.where(inquiry_id: target_id).size
+        is_asserted_by { records_result.size == len }
+        is_asserted_by { page_info_result.fetch('recordsCount') == len }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/query/inquiry_type_spec.rb
+++ b/inquiry_api/spec/requests/graphql/query/inquiry_type_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::InquiryType, type: :request do
+  before do
+    @model_key = :inquiry
+    @models_key = @model_key.to_s.downcase.pluralize.camelize(:lower).to_sym
+    @models_list_key = "#{@models_key}List".to_sym
+  end
+
+  describe '単数取得' do
+    let(:record) { create @model_key }
+    let(:query) do
+      <<~QUERY
+        query {
+          #{@model_key}(id: #{record.id}) {
+            id
+          }
+        }
+      QUERY
+    end
+
+    it '指定したレコードが取得できること' do
+      result = AppSchema.execute query
+      res = result.dig 'data', @model_key.to_s
+
+      expect(res).to include(
+        'id' => record.id.to_s
+      )
+    end
+  end
+
+  describe '一覧取得' do
+    before do
+      records = create_list @model_key, 5
+      records.each do |record|
+        record.progress.update(**attributes_for(:progress))
+      end
+    end
+    let(:records) { Inquiry.all.order(id: :asc) }
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(staff_id: nil, state: nil, fields_cont: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_key}(#{staff_id.present? ? "staffId: #{staff_id}, " : nil}#{state.present? ? "state: #{state}, " : nil}fieldsCont: "#{fields_cont}", order: "#{order}") {
+            id
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'レコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids
+        end
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids.reverse
+        end
+      end
+    end
+
+    context 'staff_idが与えられた場合' do
+      it 'staff_idが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(staff_id: 1)
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == Progress.where(staff_id: 1).size }
+      end
+    end
+
+    context 'stateが与えられた場合' do
+      it 'stateが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(state: 'waiting')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == Progress.waiting.size }
+      end
+    end
+
+    context 'fieldsContが与えられた場合' do
+      before do
+        records[0..1].map do |record|
+          record.update name: 'ABCD'
+        end
+      end
+      it '対象カラム内で与えられた値と部分一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(fields_cont: 'ABCD')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == 2 }
+      end
+    end
+  end
+
+  describe 'ページネーション' do
+    before do
+      records = create_list @model_key, 30
+      records.each do |record|
+        record.progress.update(**attributes_for(:progress))
+      end
+    end
+    let(:records) { Inquiry.all.order(id: :asc) }
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(page: nil, per: nil, fields_cont: nil, staff_id: nil, state: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_list_key}(#{page.present? ? "page: #{page}, " : nil}#{per.present? ? "per: #{per}, " : nil}#{staff_id.present? ? "staffId: #{staff_id}, " : nil}#{state.present? ? "state: #{state}, " : nil}fieldsCont: "#{fields_cont}", order: "#{order}") {
+            #{@models_key} {
+              id
+            }
+            pageInfo {
+              currentPage
+              pagesCount
+              recordsCount
+              limit
+            }
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'per: 25, page: 1の状態でレコードの一覧がページネーション付きで取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'per / pageが与えられた場合' do
+      it 'レコードの一覧が指定されたlimit / offsetで取得できること' do
+        records
+        result = AppSchema.execute query(per: 20, page: 2)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 10 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[20...30]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids.reverse[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'staff_idが与えられた場合' do
+      it 'staff_idが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(staff_id: 1, per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        len = Progress.where(staff_id: 1).size
+        is_asserted_by { records_result.size == len }
+        is_asserted_by { page_info_result.fetch('recordsCount') == len }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+
+    context 'stateが与えられた場合' do
+      it 'stateが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(state: 'waiting', per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        len = Progress.waiting.size
+        is_asserted_by { records_result.size == len }
+        is_asserted_by { page_info_result.fetch('recordsCount') == len }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+
+    context 'fieldsContが与えられた場合' do
+      before do
+        records[0..1].map do |record|
+          record.update name: 'ABCD'
+        end
+      end
+      it '対象カラム内で与えられた値と部分一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(fields_cont: 'ABCD', per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 2 }
+        is_asserted_by { page_info_result.fetch('recordsCount') == 2 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/query/menu_type_spec.rb
+++ b/inquiry_api/spec/requests/graphql/query/menu_type_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::MenuType, type: :request do
+  before do
+    @model_key = :menu
+    @models_key = @model_key.to_s.downcase.pluralize.camelize(:lower).to_sym
+    @models_list_key = "#{@models_key}List".to_sym
+  end
+
+  describe '単数取得' do
+    let(:record) { create @model_key }
+    let(:query) do
+      <<~QUERY
+        query {
+          #{@model_key}(id: #{record.id}) {
+            id
+          }
+        }
+      QUERY
+    end
+
+    it '指定したレコードが取得できること' do
+      result = AppSchema.execute query
+      res = result.dig 'data', @model_key.to_s
+
+      expect(res).to include(
+        'id' => record.id.to_s
+      )
+    end
+  end
+
+  describe '一覧取得' do
+    let(:records) { create_list @model_key, 5 }
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(order: nil)
+      <<~QUERY
+        query {
+          #{@models_key}(order: "#{order}") {
+            id
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'レコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids
+        end
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids.reverse
+        end
+      end
+    end
+  end
+
+  describe 'ページネーション' do
+    let(:records) { create_list @model_key, 30 }
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(page: nil, per: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_list_key}(#{page.present? ? "page: #{page}, " : nil}#{per.present? ? "per: #{per}, " : nil}order: "#{order}") {
+            #{@models_key} {
+              id
+            }
+            pageInfo {
+              currentPage
+              pagesCount
+              recordsCount
+              limit
+            }
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'per: 25, page: 1の状態でレコードの一覧がページネーション付きで取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'per / pageが与えられた場合' do
+      it 'レコードの一覧が指定されたlimit / offsetで取得できること' do
+        records
+        result = AppSchema.execute query(per: 20, page: 2)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 10 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[20...30]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids.reverse[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+  end
+end

--- a/inquiry_api/spec/requests/graphql/query/progress_type_spec.rb
+++ b/inquiry_api/spec/requests/graphql/query/progress_type_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::ProgressType, type: :request do
+  before do
+    @model_key = :progress
+    @models_key = @model_key.to_s.downcase.pluralize.camelize(:lower).to_sym
+    @models_list_key = "#{@models_key}List".to_sym
+  end
+
+  describe '単数取得' do
+    let(:record) { create @model_key }
+    let(:query) do
+      <<~QUERY
+        query {
+          #{@model_key}(id: #{record.id}) {
+            id
+          }
+        }
+      QUERY
+    end
+
+    it '指定したレコードが取得できること' do
+      result = AppSchema.execute query
+      res = result.dig 'data', @model_key.to_s
+
+      expect(res).to include(
+        'id' => record.id.to_s
+      )
+    end
+  end
+
+  describe '一覧取得' do
+    before do
+      inquiries = create_list :inquiry, 5
+      inquiries.each do |inquiry|
+        inquiry.progress.update(**attributes_for(:progress))
+      end
+    end
+    let(:records) { Progress.all.order(id: :asc) }
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(staff_id: nil, state: nil, rank: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_key}(#{staff_id.present? ? "staffId: #{staff_id}, " : nil}#{state.present? ? "state: #{state}, " : nil}#{rank.present? ? "rank: #{rank}, " : nil} order: "#{order}") {
+            id
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'レコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids
+        end
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids.reverse
+        end
+      end
+    end
+
+    context 'staff_idが与えられた場合' do
+      it 'staff_idが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(staff_id: 1)
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == Progress.where(staff_id: 1).size }
+      end
+    end
+
+    context 'stateが与えられた場合' do
+      it 'stateが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(state: 'waiting')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == Progress.waiting.size }
+      end
+    end
+
+    context 'rankが与えられた場合' do
+      it 'rankが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(rank: 'a')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == Progress.a.size }
+      end
+    end
+  end
+
+  describe 'ページネーション' do
+    before do
+      inquiries = create_list :inquiry, 30
+      inquiries.each do |inquiry|
+        inquiry.progress.update(**attributes_for(:progress))
+      end
+    end
+    let(:records) { Progress.all.order(id: :asc) }
+    let(:record_ids) { records.map(&:id).reverse }
+    def query(page: nil, per: nil, rank: nil, staff_id: nil, state: nil, order: nil)
+      <<~QUERY
+        query {
+          #{@models_list_key}(#{page.present? ? "page: #{page}, " : nil}#{per.present? ? "per: #{per}, " : nil}#{staff_id.present? ? "staffId: #{staff_id}, " : nil}#{state.present? ? "state: #{state}, " : nil}#{rank.present? ? "rank: #{rank}, " : nil}order: "#{order}") {
+            #{@models_key} {
+              id
+            }
+            pageInfo {
+              currentPage
+              pagesCount
+              recordsCount
+              limit
+            }
+          }
+        }
+      QUERY
+    end
+
+    context 'variantsを指定しない場合' do
+      it 'per: 25, page: 1の状態でレコードの一覧がページネーション付きで取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'per / pageが与えられた場合' do
+      it 'レコードの一覧が指定されたlimit / offsetで取得できること' do
+        records
+        result = AppSchema.execute query(per: 20, page: 2)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 10 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[20...30]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids.reverse[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'staff_idが与えられた場合' do
+      it 'staff_idが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(staff_id: 1, per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        len = Progress.where(staff_id: 1).size
+        is_asserted_by { records_result.size == len }
+        is_asserted_by { page_info_result.fetch('recordsCount') == len }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+
+    context 'stateが与えられた場合' do
+      it 'stateが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(state: 'waiting', per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        len = Progress.waiting.size
+        is_asserted_by { records_result.size == len }
+        is_asserted_by { page_info_result.fetch('recordsCount') == len }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+
+    context 'rankが与えられた場合' do
+      it 'rankが与えられた値と一致するレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(rank: 'a', per: 30)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        len = Progress.a.size
+        is_asserted_by { records_result.size == len }
+        is_asserted_by { page_info_result.fetch('recordsCount') == len }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

GraphQLに対するリクエストスペックを追記。

直接リクエストするのではなく、AppSchemaのexecuteに対してクエリを投げ込む形で実装。

## 実装した機能

- [x] 各Queryに対するリクエストスペックを追加
- [x] 各Mutationに対するリクエストスペックを追加
- [x] テストに伴って細かい点を微調整