### PR TITLE
Feature/create resolvers test for user api

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - ".github/**"
       - "client/**"
+      - "user_api/spec/**"
+      - "inquiry_api/spec/**"
       - "docs/**"
       - "**.md"
 

--- a/user_api/app/graphql/app_schema.rb
+++ b/user_api/app/graphql/app_schema.rb
@@ -18,6 +18,18 @@ class AppSchema < GraphQL::Schema
     )
   end
 
+  rescue_from(ActiveRecord::RecordNotFound) do |error|
+    GraphQL::ExecutionError.new(
+      I18n.t(:record_not_found, scope: %i[activerecord errors messages]),
+      extensions: {
+        code: 'RECORD_NOT_FOUND',
+        record: {
+          model: error.model
+        }
+      }
+    )
+  end
+
   # Union and Interface Resolution
   def self.resolve_type(_abstract_type, _obj, _ctx)
     # TODO: Implement this function

--- a/user_api/app/graphql/types/query_type.rb
+++ b/user_api/app/graphql/types/query_type.rb
@@ -8,8 +8,9 @@ module Types
       argument :fields_cont, String, required: false
       argument :order, String, required: false
     end
-    def users(fields_cont: nil, order: 'created_at desc')
-      User.fields_cont(fields_cont).order(order.underscore)
+    def users(fields_cont: nil, order: nil)
+      User.fields_cont(fields_cont)
+          .order(order.present? ? order.underscore : 'id desc')
     end
 
     field :users_list, UsersListType, null: false do
@@ -18,8 +19,10 @@ module Types
       argument :fields_cont, String, required: false
       argument :order, String, required: false
     end
-    def users_list(page: 1, per: 25, fields_cont: nil, order: 'created_at desc')
-      result = User.fields_cont(fields_cont).order(order.underscore).page(page).per(per)
+    def users_list(page: 1, per: 25, fields_cont: nil, order: nil)
+      result = User.fields_cont(fields_cont)
+                   .order(order.present? ? order.underscore : 'id desc')
+                   .page(page).per(per)
       parse_connection_payload result, :users
     end
 

--- a/user_api/config/locales/ja.yml
+++ b/user_api/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
   activerecord:
     errors:
       messages:
+        record_not_found: '対象のレコードは存在しません'
         record_invalid: 'バリデーションに失敗しました: %{errors}'
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"

--- a/user_api/spec/requests/graphql/mutations/create_user_spec.rb
+++ b/user_api/spec/requests/graphql/mutations/create_user_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateUser, type: :request do
+  let(:user_attr) { attributes_for :user }
+  let(:address_attr) { attributes_for :address }
+  def input(user, address)
+    <<~INPUT
+      mutation {
+        createUser(input: {
+          companyName: "#{user[:company_name]}",
+          name: "#{user[:name]}",
+          email: "#{user[:email]}",
+          tel: "#{user[:tel]}",
+          address: {
+            postalCode: "#{address[:postal_code]}",
+            prefecture: "#{address[:prefecture]}",
+            city: "#{address[:city]}",
+            street: "#{address[:street]}",
+            building: "#{address[:building]}",
+          }
+        }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値のとき' do
+    it 'レコードが作成される' do
+      result = AppSchema.execute input(user_attr, address_attr)
+      is_asserted_by { result.dig('data', 'createUser', 'name') == user_attr[:name] }
+      is_asserted_by { User.first.name == user_attr[:name] }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは生成されない' do
+      user_attr[:email] = nil
+      result = AppSchema.execute input(user_attr, address_attr)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { User.all.size.zero? }
+    end
+  end
+end

--- a/user_api/spec/requests/graphql/mutations/create_user_spec.rb
+++ b/user_api/spec/requests/graphql/mutations/create_user_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Mutations::CreateUser, type: :request do
-  let(:user_attr) { attributes_for :user }
-  let(:address_attr) { attributes_for :address }
+  let(:user_attributes) { attributes_for :user }
+  let(:address_attributes) { attributes_for :address }
   def input(user, address)
     <<~INPUT
       mutation {
@@ -28,18 +28,18 @@ RSpec.describe Mutations::CreateUser, type: :request do
     INPUT
   end
 
-  describe '正常な値のとき' do
+  describe '正常な値を与えた場合' do
     it 'レコードが作成される' do
-      result = AppSchema.execute input(user_attr, address_attr)
-      is_asserted_by { result.dig('data', 'createUser', 'name') == user_attr[:name] }
-      is_asserted_by { User.first.name == user_attr[:name] }
+      result = AppSchema.execute input(user_attributes, address_attributes)
+      is_asserted_by { result.dig('data', 'createUser', 'name') == user_attributes[:name] }
+      is_asserted_by { User.first.name == user_attributes[:name] }
     end
   end
 
   describe 'バリデーションに引っかかった場合' do
-    it 'errorsフィールドにエラー内容が生成され、レコードは生成されない' do
-      user_attr[:email] = nil
-      result = AppSchema.execute input(user_attr, address_attr)
+    it 'errorsフィールドにエラー内容が生成され、レコードは作成されない' do
+      user_attributes[:email] = nil
+      result = AppSchema.execute input(user_attributes, address_attributes)
       is_asserted_by { result.key?('errors') }
       is_asserted_by { User.all.size.zero? }
     end

--- a/user_api/spec/requests/graphql/mutations/delete_user_spec.rb
+++ b/user_api/spec/requests/graphql/mutations/delete_user_spec.rb
@@ -5,9 +5,7 @@ require 'rails_helper'
 RSpec.describe Mutations::UpdateUser, type: :request do
   let(:user) { create :user }
   let(:user_attributes) { user.attributes.symbolize_keys }
-  let(:address) { create :address, user: user }
-  let(:address_attributes) { address.attributes.symbolize_keys }
-  def input(user, _address)
+  def input(user)
     <<~INPUT
       mutation {
         deleteUser(input: { id: "#{user[:id]}" }) {
@@ -18,18 +16,18 @@ RSpec.describe Mutations::UpdateUser, type: :request do
     INPUT
   end
 
-  describe '存在するIDのとき' do
+  describe '正常な値を与えた場合' do
     it 'レコードが削除される' do
-      result = AppSchema.execute input(user_attributes, address_attributes)
+      result = AppSchema.execute input(user_attributes)
       is_asserted_by { result.dig('data', 'deleteUser', 'name') == user.name }
       is_asserted_by { User.find_by_id(user.id).nil? }
     end
   end
 
-  describe '存在しないIDのとき' do
+  describe '存在しないIDを指定した場合' do
     it 'errorsフィールドにエラー内容が生成され、レコードは削除されない' do
       user_attributes[:id] = 0
-      result = AppSchema.execute input(user_attributes, address_attributes)
+      result = AppSchema.execute input(user_attributes)
       is_asserted_by { result.key?('errors') }
       is_asserted_by { User.find(user.id).present? }
     end

--- a/user_api/spec/requests/graphql/mutations/delete_user_spec.rb
+++ b/user_api/spec/requests/graphql/mutations/delete_user_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateUser, type: :request do
+  let(:user) { create :user }
+  let(:user_attributes) { user.attributes.symbolize_keys }
+  let(:address) { create :address, user: user }
+  let(:address_attributes) { address.attributes.symbolize_keys }
+  def input(user, _address)
+    <<~INPUT
+      mutation {
+        deleteUser(input: { id: "#{user[:id]}" }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '存在するIDのとき' do
+    it 'レコードが削除される' do
+      result = AppSchema.execute input(user_attributes, address_attributes)
+      is_asserted_by { result.dig('data', 'deleteUser', 'name') == user.name }
+      is_asserted_by { User.find_by_id(user.id).nil? }
+    end
+  end
+
+  describe '存在しないIDのとき' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは削除されない' do
+      user_attributes[:id] = 0
+      result = AppSchema.execute input(user_attributes, address_attributes)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { User.find(user.id).present? }
+    end
+  end
+end

--- a/user_api/spec/requests/graphql/mutations/update_user_spec.rb
+++ b/user_api/spec/requests/graphql/mutations/update_user_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Mutations::UpdateUser, type: :request do
     INPUT
   end
 
-  describe '正常な値のとき' do
-    it 'レコードが作成される' do
+  describe '正常な値を与えた場合' do
+    it 'レコードが更新される' do
       new_name = 'asserted_name'
       user.name = new_name
       result = AppSchema.execute input(user_attributes, address_attributes)
@@ -42,12 +42,21 @@ RSpec.describe Mutations::UpdateUser, type: :request do
   end
 
   describe 'バリデーションに引っかかった場合' do
-    it 'errorsフィールドにエラー内容が生成され、レコードは生成されない' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
       before_email = user.email
       user.email = nil
       result = AppSchema.execute input(user_attributes, address_attributes)
       is_asserted_by { result.key?('errors') }
       is_asserted_by { user.reload.email == before_email }
+    end
+  end
+
+  describe '存在しないIDを指定した場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは更新されない' do
+      user_attributes[:id] = 0
+      result = AppSchema.execute input(user_attributes, address_attributes)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { User.find(user.id).present? }
     end
   end
 end

--- a/user_api/spec/requests/graphql/mutations/update_user_spec.rb
+++ b/user_api/spec/requests/graphql/mutations/update_user_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mutations::UpdateUser, type: :request do
+  let(:user) { create :user }
+  let(:user_attributes) { user.attributes.symbolize_keys }
+  let(:address) { create :address, user: user }
+  let(:address_attributes) { address.attributes.symbolize_keys }
+  def input(user, address)
+    <<~INPUT
+      mutation {
+        updateUser(input: {
+          #{user.fetch(:id) ? "id: #{user[:id]}" : nil}
+          companyName: "#{user[:company_name]}",
+          name: "#{user[:name]}",
+          email: "#{user[:email]}",
+          tel: "#{user[:tel]}",
+          address: {
+            postalCode: "#{address[:postal_code]}",
+            prefecture: "#{address[:prefecture]}",
+            city: "#{address[:city]}",
+            street: "#{address[:street]}",
+            building: "#{address[:building]}",
+          }
+        }) {
+          id
+          name
+        }
+      }
+    INPUT
+  end
+
+  describe '正常な値のとき' do
+    it 'レコードが作成される' do
+      new_name = 'asserted_name'
+      user.name = new_name
+      result = AppSchema.execute input(user_attributes, address_attributes)
+      is_asserted_by { result.dig('data', 'updateUser', 'name') == new_name }
+      is_asserted_by { user.reload.name == new_name }
+    end
+  end
+
+  describe 'バリデーションに引っかかった場合' do
+    it 'errorsフィールドにエラー内容が生成され、レコードは生成されない' do
+      before_email = user.email
+      user.email = nil
+      result = AppSchema.execute input(user_attributes, address_attributes)
+      is_asserted_by { result.key?('errors') }
+      is_asserted_by { user.reload.email == before_email }
+    end
+  end
+end

--- a/user_api/spec/requests/graphql/query/user_type_spec.rb
+++ b/user_api/spec/requests/graphql/query/user_type_spec.rb
@@ -3,61 +3,96 @@
 require 'rails_helper'
 
 RSpec.describe Types::UserType, type: :request do
-  describe 'user' do
-    let(:user) { create :user }
+  before do
+    @model_key = :user
+    @models_key = @model_key.to_s.downcase.pluralize.camelize(:lower).to_sym
+    @models_list_key = "#{@models_key}List".to_sym
+  end
+
+  describe '単数取得' do
+    let(:record) { create @model_key }
     let(:query) do
       <<~QUERY
         query {
-          user(id: #{user.id}) {
+          #{@model_key}(id: #{record.id}) {
             id
           }
         }
       QUERY
     end
 
-    it '指定したUserが取得できること' do
+    it '指定したレコードが取得できること' do
       result = AppSchema.execute query
-      res = result.dig 'data', 'user'
+      res = result.dig 'data', @model_key.to_s
 
       expect(res).to include(
-        'id' => user.id.to_s
+        'id' => record.id.to_s
       )
     end
   end
 
-  describe 'users' do
-    let(:users) { create_list :user, 5 }
-    let(:user_ids) { users.map(&:id).sort }
-    def query(fields_cont:, order:)
+  describe '一覧取得' do
+    let(:records) { create_list @model_key, 5 }
+    let(:record_ids) { records.map(&:id).sort.reverse }
+    def query(fields_cont: nil, order: nil)
       <<~QUERY
         query {
-          users(fieldsCont: "#{fields_cont}", order: "#{order}") {
+          #{@models_key}(fieldsCont: "#{fields_cont}", order: "#{order}") {
             id
           }
         }
       QUERY
     end
 
-    it 'Userの一覧が取得できること' do
-      users
-      result = AppSchema.execute query(fields_cont: nil, order: 'id asc')
-      users_result = result.dig 'data', 'users'
+    context 'variantsを指定しない場合' do
+      it 'レコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_key.to_s
 
-      is_asserted_by { users_result.size == users.size }
-      is_asserted_by do
-        users_result.map { |u| u['id'].to_i }.sort == user_ids
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids
+        end
+      end
+    end
+
+    context 'fieldsContが与えられた場合' do
+      before do
+        records
+        create_list @model_key, 2, name: 'ABCD'
+      end
+
+      it '検索対象カラムに与えられた値を含むレコードの一覧が取得できること' do
+        result = AppSchema.execute query(fields_cont: 'ABCD')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == 2 }
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_key.to_s
+
+        is_asserted_by { records_result.size == records.size }
+        is_asserted_by do
+          records_result.map { |u| u['id'].to_i } == record_ids.reverse
+        end
       end
     end
   end
 
-  describe 'usersList' do
-    let(:users) { create_list :user, 30 }
-    let(:user_ids) { users.map(&:id).sort }
-    def query(page:, per:, fields_cont:, order:)
+  describe 'ページネーション' do
+    let(:records) { create_list @model_key, 30 }
+    let(:record_ids) { records.map(&:id).sort.reverse }
+    def query(page: nil, per: nil, fields_cont: nil, order: nil)
       <<~QUERY
         query {
-          usersList(page: #{page}, per: #{per}, fieldsCont: "#{fields_cont}", order: "#{order}") {
-            users {
+          #{@models_list_key}(#{page.present? ? "page: #{page}" : nil}, #{per.present? ? "per: #{per}" : nil}, fieldsCont: "#{fields_cont}", order: "#{order}") {
+            #{@models_key} {
               id
             }
             pageInfo {
@@ -71,18 +106,69 @@ RSpec.describe Types::UserType, type: :request do
       QUERY
     end
 
-    it 'Userの一覧がページネーション付きで取得できること' do
-      users
-      result = AppSchema.execute query(page: 1, per: 10, fields_cont: nil, order: 'id asc')
-      users_result = result.dig 'data', 'usersList', 'users'
-      page_info_result = result.dig 'data', 'usersList', 'pageInfo'
+    context 'variantsを指定しない場合' do
+      it 'per: 25, page: 1の状態でレコードの一覧がページネーション付きで取得できること' do
+        records
+        result = AppSchema.execute query
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
 
-      is_asserted_by { users_result.size == 10 }
-      is_asserted_by do
-        users_result.map { |u| u.fetch('id').to_i }.sort == user_ids[0...10]
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
       end
-      is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
-      is_asserted_by { page_info_result.fetch('pagesCount') == 3 }
+    end
+
+    context 'per / pageが与えられた場合' do
+      it 'レコードの一覧が指定されたlimit / offsetで取得できること' do
+        records
+        result = AppSchema.execute query(per: 20, page: 2)
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 10 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids[20...30]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
+    end
+
+    context 'fieldsContが与えられた場合' do
+      before do
+        records
+        create_list @model_key, 2, name: 'ABCD'
+      end
+
+      it '検索対象カラムに与えられた値を含むレコードの一覧が取得できること' do
+        result = AppSchema.execute query(fields_cont: 'ABCD')
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 2 }
+        is_asserted_by { page_info_result.fetch('recordsCount') == 2 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 1 }
+      end
+    end
+
+    context 'orderが与えられた場合' do
+      it '与えられた値に基づいてソートされたレコードの一覧が取得できること' do
+        records
+        result = AppSchema.execute query(order: 'id asc')
+        records_result = result.dig 'data', @models_list_key.to_s, @models_key.to_s
+        page_info_result = result.dig 'data', @models_list_key.to_s, 'pageInfo'
+
+        is_asserted_by { records_result.size == 25 }
+        is_asserted_by do
+          records_result.map { |u| u.fetch('id').to_i } == record_ids.reverse[0...25]
+        end
+        is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+        is_asserted_by { page_info_result.fetch('pagesCount') == 2 }
+      end
     end
   end
 end

--- a/user_api/spec/requests/graphql/query/user_type_spec.rb
+++ b/user_api/spec/requests/graphql/query/user_type_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::UserType, type: :request do
+  describe 'user' do
+    let(:user) { create :user }
+    let(:query) do
+      <<~QUERY
+        query {
+          user(id: #{user.id}) {
+            id
+          }
+        }
+      QUERY
+    end
+
+    it '指定したUserが取得できること' do
+      result = AppSchema.execute query
+      res = result.dig 'data', 'user'
+
+      expect(res).to include(
+        'id' => user.id.to_s
+      )
+    end
+  end
+
+  describe 'users' do
+    let(:users) { create_list :user, 5 }
+    let(:user_ids) { users.map(&:id).sort }
+    def query(fields_cont:, order:)
+      <<~QUERY
+        query {
+          users(fieldsCont: "#{fields_cont}", order: "#{order}") {
+            id
+          }
+        }
+      QUERY
+    end
+
+    it 'Userの一覧が取得できること' do
+      users
+      result = AppSchema.execute query(fields_cont: nil, order: 'id asc')
+      users_result = result.dig 'data', 'users'
+
+      is_asserted_by { users_result.size == users.size }
+      is_asserted_by do
+        users_result.map { |u| u['id'].to_i }.sort == user_ids
+      end
+    end
+  end
+
+  describe 'usersList' do
+    let(:users) { create_list :user, 30 }
+    let(:user_ids) { users.map(&:id).sort }
+    def query(page:, per:, fields_cont:, order:)
+      <<~QUERY
+        query {
+          usersList(page: #{page}, per: #{per}, fieldsCont: "#{fields_cont}", order: "#{order}") {
+            users {
+              id
+            }
+            pageInfo {
+              currentPage
+              pagesCount
+              recordsCount
+              limit
+            }
+          }
+        }
+      QUERY
+    end
+
+    it 'Userの一覧がページネーション付きで取得できること' do
+      users
+      result = AppSchema.execute query(page: 1, per: 10, fields_cont: nil, order: 'id asc')
+      users_result = result.dig 'data', 'usersList', 'users'
+      page_info_result = result.dig 'data', 'usersList', 'pageInfo'
+
+      is_asserted_by { users_result.size == 10 }
+      is_asserted_by do
+        users_result.map { |u| u.fetch('id').to_i }.sort == user_ids[0...10]
+      end
+      is_asserted_by { page_info_result.fetch('recordsCount') == 30 }
+      is_asserted_by { page_info_result.fetch('pagesCount') == 3 }
+    end
+  end
+end


### PR DESCRIPTION
## 概要

GraphQLに対するリクエストスペックを追記。

直接リクエストするのではなく、AppSchemaのexecuteに対してクエリを投げ込む形で実装。

## 実装した機能

- [x] 各Queryに対するリクエストスペックを追加
- [x] 各Mutationに対するリクエストスペックを追加
- [x] テストに伴って細かい点を微調整
- [x] テストのみではビルドが発生しないようにworkflowを調整