### PR TITLE
Feature/add test to staff resolvers

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -13,6 +13,7 @@ on:
       - "inquiry_api/spec/**"
       - "docs/**"
       - "**.md"
+      - "**_test.go"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/staff_api_test.yml
+++ b/.github/workflows/staff_api_test.yml
@@ -45,7 +45,9 @@ jobs:
         run: go mod download
 
       - name: Test code
-        run: go test -v ./...
+        run: |
+          go test -v ./
+          go test -v ./entity
         env:
           DB_HOST: localhost
           DB_USER: postgres

--- a/client/components/globalStateProvider.tsx
+++ b/client/components/globalStateProvider.tsx
@@ -13,7 +13,6 @@ import Loader from "react-loader-spinner";
 import { generateSessionData, AuthResponseData } from "../modules/jwt";
 import { useSnackbar } from "notistack";
 import { useGetStaffbyEmailQuery } from "../graphql/client";
-import Box from "@mui/material/Box";
 
 const fetchRefreshToken = (token: string) => {
   const url = `${process.env.NEXT_PUBLIC_API_HOST}/api/refresh_token`;
@@ -58,17 +57,18 @@ const GlobalStateProvider: FC = ({ children }) => {
     } else {
       fetchRefreshToken(jwt)
         .then((response) => {
+          setLoading(false);
           removeCookie("jwt");
           setCookie("jwt", response.data.token, { path: "/" });
           setSession(generateSessionData(response.data));
         })
         .catch((err) => {
+          setLoading(false);
           removeCookie("jwt");
-          router.replace("/login");
           enqueueSnackbar("セッションが切れています", { variant: "error" });
           setSession(null);
-        })
-        .finally(() => setLoading(false));
+          router.replace("/login");
+        });
     }
   }, [
     router,
@@ -95,9 +95,9 @@ const GlobalStateProvider: FC = ({ children }) => {
           })
           .catch((err) => {
             removeCookie("jwt");
-            router.replace("/login");
             enqueueSnackbar("セッションが切れています", { variant: "error" });
             setSession(null);
+            router.replace("/login");
           });
       }
     }, 60000);
@@ -106,7 +106,7 @@ const GlobalStateProvider: FC = ({ children }) => {
 
   return (
     <>
-      <Box sx={{ m: 0, p: 0 }}>{children}</Box>
+      {children}
       {loading && (
         <Backdrop open={loading}>
           <Loader type="MutatingDots" height={100} width={100} />

--- a/client/pages/inquiries/[id].tsx
+++ b/client/pages/inquiries/[id].tsx
@@ -1,8 +1,6 @@
 import { FC, useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
-import { useSetRecoilState } from "recoil";
-import { globalLoadingState } from "../../modules/atoms";
 import Container from "@mui/material/Container";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
@@ -67,7 +65,6 @@ const InquiryShow: FC = () => {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [userModalOpen, setUserModalOpen] = useState<boolean>(false);
   const [progressId, setProgressId] = useState<string | null>(null);
-  const setLoading = useSetRecoilState(globalLoadingState);
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
   const { id } = router.query;
@@ -155,8 +152,6 @@ const InquiryShow: FC = () => {
 
     setProgressId(data.inquiry.progress.id);
   }, [data]);
-
-  useEffect(() => setLoading(loading), [loading]);
 
   return (
     <>

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/dist/client/router";
 import axios from "axios";
 import { useCookies } from "react-cookie";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { globalLoadingState, sessionState } from "../modules/atoms";
 import { useSnackbar } from "notistack";
 import Avatar from "@mui/material/Avatar";
@@ -57,13 +57,12 @@ export default function Login() {
           setCookie("jwt", response.data.token, { path: "/" });
           const sessionData = generateSessionData(response.data);
           setSession(sessionData);
+          setGlobalLoading(false);
           router.replace("/");
         })
         .catch((err) => {
           removeCookie("jwt");
           setSession(null);
-        })
-        .finally(() => {
           setGlobalLoading(false);
         });
     }

--- a/client/pages/staffs/[id].tsx
+++ b/client/pages/staffs/[id].tsx
@@ -1,6 +1,7 @@
 import { FC, useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
+import { currentStaffState } from "../../modules/atoms";
 import Link from "next/link";
 import { useSnackbar } from "notistack";
 import Container from "@mui/material/Container";
@@ -10,7 +11,6 @@ import Paper from "@mui/material/Paper";
 import Avatar from "@mui/material/Avatar";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
-import { currentStaffState, globalLoadingState } from "../../modules/atoms";
 import {
   useGetStaffByIdQuery,
   useUpdateStaffMutation,
@@ -50,7 +50,6 @@ const StaffShow: FC = (props) => {
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
   const currentStaff = useRecoilValue(currentStaffState);
-  const setLoading = useSetRecoilState(globalLoadingState);
   const { id } = router.query;
 
   const { data, loading, error, refetch } = useGetStaffByIdQuery({
@@ -160,8 +159,6 @@ const StaffShow: FC = (props) => {
       };
     }
   };
-
-  useEffect(() => setLoading(loading), [loading]);
 
   return (
     <Container maxWidth="md" sx={{ marginTop: 2 }}>

--- a/client/pages/users/[id].tsx
+++ b/client/pages/users/[id].tsx
@@ -2,8 +2,6 @@ import { FC, useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { useSnackbar } from "notistack";
-import { useSetRecoilState } from "recoil";
-import { globalLoadingState } from "../../modules/atoms";
 import Container from "@mui/material/Container";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
@@ -131,7 +129,6 @@ const UserShow: FC = (props) => {
   const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
   const { id } = router.query;
-  const setLoading = useSetRecoilState(globalLoadingState);
 
   const { data, loading, error, refetch } = useGetUserByIdQuery({
     skip: !id,
@@ -208,8 +205,6 @@ const UserShow: FC = (props) => {
   };
 
   const handleDelete = () => setDeleteId(id as string);
-
-  useEffect(() => setLoading(loading), [loading]);
 
   return (
     <Container maxWidth="md" sx={{ marginTop: 2 }}>

--- a/staff_api/graph/resolver.go
+++ b/staff_api/graph/resolver.go
@@ -1,9 +1,3 @@
 package graph
 
-import (
-	"gorm.io/gorm"
-)
-
-type Resolver struct {
-	DB *gorm.DB
-}
+type Resolver struct{}

--- a/staff_api/graphql_test.go
+++ b/staff_api/graphql_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"staff_api/database"
+	"staff_api/entity"
+	"staff_api/graph"
+	"staff_api/graph/generated"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/99designs/gqlgen/graphql/handler"
+
+	// "github.com/99designs/gqlgen/graphql/introspection"
+	"github.com/stretchr/testify/assert"
+	// "github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestGraphql(t *testing.T) {
+	os.Setenv("GO_ENV", "test")
+	db, err := database.Connect()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	err = db.AutoMigrate(&entity.Staff{})
+	if err != nil {
+		log.Panic(err)
+	}
+
+	staffs := createStaffs(t, 30)
+	fid := fmt.Sprintf("%d", staffs[0].ID)
+
+	c := client.New(handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}})))
+
+	t.Run("Staff: Success", func(t *testing.T) {
+		var resp struct {
+			Staff struct {
+				ID string
+			}
+		}
+		c.MustPost(fmt.Sprintf(`
+		query {
+			staff(id: %s) {
+				id
+			}
+		}`, fid), &resp)
+		assert.Equal(t, fid, resp.Staff.ID)
+	})
+
+	t.Run("Staffs: Success", func(t *testing.T) {
+		var resp struct {
+			Staffs []struct {
+				ID string
+			}
+		}
+		c.MustPost(`
+		query {
+			staffs {
+				id
+			}
+		}`, &resp)
+		assert.Equal(t, 30, len(resp.Staffs))
+	})
+
+	t.Run("StaffsList: Success", func(t *testing.T) {
+		var resp struct {
+			StaffsList struct {
+				Staffs []struct {
+					ID string
+				}
+				PageInfo struct {
+					CurrentPage  int
+					PagesCount   int
+					RecordsCount int
+					Limit        int
+				}
+			}
+		}
+		c.MustPost(`
+		query {
+			staffsList(per: 20, page: 2) {
+				staffs {
+					id
+				}
+				pageInfo {
+					currentPage
+					pagesCount
+					recordsCount
+					limit
+				}
+			}
+		}`, &resp)
+		assert.Equal(t, 10, len(resp.StaffsList.Staffs))
+		assert.Equal(t, 30, resp.StaffsList.PageInfo.RecordsCount)
+		assert.Equal(t, 2, resp.StaffsList.PageInfo.PagesCount)
+	})
+
+	t.Run("CreateStaff: Success", func(t *testing.T) {
+		blen := getRecordSize()
+		var resp struct {
+			CreateStaff struct {
+				ID   string
+				Name string
+			}
+		}
+		c.MustPost(`
+		mutation {
+			createStaff(input: {
+				name: "create_staff_test",
+				email: "create_staff_test@email.com",
+				password: "password"
+			}) {
+				id
+				name
+			}
+		}`, &resp)
+		alen := getRecordSize()
+		assert.Equal(t, blen+1, alen)
+		assert.Equal(t, "create_staff_test", resp.CreateStaff.Name)
+	})
+
+	t.Run("CreateStaff: Email Invalid", func(t *testing.T) {
+		var resp struct{}
+		err := c.Post(`
+		mutation {
+			createStaff(input: {
+				name: "create_staff_test",
+				email: "",
+				password: "password"
+			}) {
+				id
+				name
+			}
+		}`, &resp)
+		assert.Error(t, err)
+	})
+
+	t.Run("UpdateStaff: Success", func(t *testing.T) {
+		var resp struct {
+			UpdateStaff struct {
+				ID   string
+				Name string
+			}
+		}
+		c.MustPost(fmt.Sprintf(`
+		mutation {
+			updateStaff(input: {
+				id: %s
+				name: "update_staff_test",
+			}) {
+				id
+				name
+			}
+		}`, fid), &resp)
+		assert.Equal(t, "update_staff_test", resp.UpdateStaff.Name)
+	})
+
+	t.Run("ChangeStaffPassword: Success", func(t *testing.T) {
+		var resp struct {
+			ChangeStaffPassword struct {
+				ID string
+			}
+		}
+		c.MustPost(fmt.Sprintf(`
+		mutation {
+			changeStaffPassword(input: {
+				id: %s
+				password: "password",
+				newPassword: "newpassword"
+			}) {
+				id
+			}
+		}`, fid), &resp)
+		assert.True(
+			t,
+			entity.Staff{}.IsAuthenticated(staffs[0].Email, "newpassword"),
+		)
+	})
+
+	t.Run("UpdateStaffIcon: Success", func(t *testing.T) {
+		var resp struct {
+			UploadStaffIcon struct {
+				ID   string
+				Icon string
+			}
+		}
+		c.MustPost(fmt.Sprintf(`
+		mutation {
+			uploadStaffIcon(input: {
+				id: %s,
+				icon: "text"
+			}) {
+				id
+				icon
+			}
+		}`, fid), &resp)
+		assert.Equal(t, "text", resp.UploadStaffIcon.Icon)
+	})
+
+	t.Run("DeleteStaffIcon: Success", func(t *testing.T) {
+		var resp struct {
+			DeleteStaffIcon struct {
+				ID   string
+				Icon string
+			}
+		}
+		c.MustPost(fmt.Sprintf(`
+		mutation {
+			deleteStaffIcon(input: {
+				id: %s,
+			}) {
+				id
+				icon
+			}
+		}`, fid), &resp)
+		assert.Equal(t, "", resp.DeleteStaffIcon.Icon)
+	})
+
+	t.Run("DeleteStaff: Success", func(t *testing.T) {
+		blen := getRecordSize()
+		var resp struct {
+			DeleteStaff struct {
+				ID string
+			}
+		}
+		c.MustPost(fmt.Sprintf(`
+		mutation {
+			deleteStaff(input: {
+				id: %s,
+			}) {
+				id
+			}
+		}`, fid), &resp)
+		alen := getRecordSize()
+		assert.Equal(t, blen-1, alen)
+		assert.Equal(t, fid, resp.DeleteStaff.ID)
+	})
+
+	cleanStaffs()
+}
+
+func createStaffs(t *testing.T, size int) []entity.Staff {
+	cleanStaffs()
+	if size < 1 {
+		return []entity.Staff{}
+	}
+
+	var staffs []entity.Staff
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password"), 10)
+	for i := 1; i <= size; i++ {
+		staffs = append(staffs, entity.Staff{
+			Name:           fmt.Sprintf("テスト%d", i),
+			Email:          fmt.Sprintf("main_test%d@example.com", i),
+			PasswordDigest: hashed,
+		})
+	}
+
+	if err := database.GetDB().Create(&staffs).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	return staffs
+}
+
+func getRecordSize() int64 {
+	var staffs []entity.Staff
+	return database.GetDB().Find(&staffs).RowsAffected
+}
+
+func cleanStaffs() {
+	database.GetDB().Exec("DELETE FROM staffs")
+}

--- a/staff_api/main.go
+++ b/staff_api/main.go
@@ -21,5 +21,5 @@ func main() {
 	}
 
 	go server.RunGrpc()
-	server.RunGraphql(db)
+	server.RunGraphql()
 }

--- a/staff_api/server/graphql.go
+++ b/staff_api/server/graphql.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
-	"gorm.io/gorm"
 )
 
 const gqlPort = "3001"
 
-func RunGraphql(db *gorm.DB) {
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{DB: db}}))
+func RunGraphql() {
+	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
 
 	http.Handle("/health_check", http.HandlerFunc(handlers.HealthCheckHandler))
 


### PR DESCRIPTION
## 概要

Staff APIにGraphQLのリゾルバー用テストを追加。

またセッション周りの調整にClientもすこし編集

## 実装した機能

- [x] Staff APIのResolverに対してSuccessパターンのテストを記述
- [x] UI側のセッション周りを調整

## 未実装の機能

- [ ] バリデーションごとのエラーテストなど、細かい粒度のResolverテストの追加