### PR TITLE
hot fix for bundle platform in user-api

### DIFF
--- a/user_api/Gemfile.lock
+++ b/user_api/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     globalid (0.5.2)
       activesupport (>= 5.0)
     google-protobuf (3.18.1)
+    google-protobuf (3.18.1-x86_64-linux)
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
@@ -123,6 +124,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.0.2.0)
@@ -230,6 +233,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  x86_64-linux-musl
 
 DEPENDENCIES
   annotate


### PR DESCRIPTION
## 概要

Gemfile.lockを生成しなおしたことによるArchロックインのホワイトリスト追加